### PR TITLE
fix(frontend): sanitize markdown link hrefs to block javascript: URIs

### DIFF
--- a/frontend/src/components/Markdown.jsx
+++ b/frontend/src/components/Markdown.jsx
@@ -121,8 +121,16 @@ function inline(text) {
       if (tok.startsWith('**')) out.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
       else if (tok.startsWith('[')) {
         const lm = tok.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+        const href = lm[2];
+        const isSafe = /^(?:https?:\/\/|#|\/)/.test(href);
         out.push(
-          <a key={key++} href={lm[2]} target="_blank" rel="noreferrer" style={linkStyle}>
+          <a
+            key={key++}
+            href={isSafe ? href : ''}
+            target="_blank"
+            rel="noreferrer"
+            style={linkStyle}
+          >
             {lm[1]}
           </a>
         );


### PR DESCRIPTION
markdown.jsx was rendering links from scan reports straight into the dom without touching the href. a prompt-injected agent could stuff a javascript: uri into its output and if the operator clicks it the browser runs it. the threat model already says prompt injection is not fully preventable, so this is a real path.\n\nthe fix only allows http/https, fragment links, and relative paths. everything else (javascript:, data:, vbscript:) gets an empty href.