### PR TITLE
fix: prevent "cannot set path in scalar" when resuming scans

### DIFF
--- a/backend/src/routes/scans.js
+++ b/backend/src/routes/scans.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../db.js';
 import {
   validateScan,
@@ -161,7 +162,9 @@ export async function patchScanIfPresent(tx, scanId, body, { assertAvailable, av
     }
     data.status = status;
     if (status === 'pending' && existing.status !== 'pending') {
-      data.reasoning = null;
+      // Prisma writes plain null as JSON 'null' (a jsonb scalar), which breaks
+      // the engine's jsonb_set(reasoning, ...) updates; DbNull stores SQL NULL.
+      data.reasoning = Prisma.DbNull;
       data.lastResumedAt = new Date();
     }
   }

--- a/engine/open_kritt_engine/db.py
+++ b/engine/open_kritt_engine/db.py
@@ -497,7 +497,10 @@ class Database:
             """
             UPDATE public.scans
             SET reasoning = jsonb_set(
-                    coalesce(reasoning, '{}'::jsonb),
+                    CASE WHEN jsonb_typeof(reasoning) = 'object'
+                         THEN reasoning
+                         ELSE '{}'::jsonb
+                    END,
                     '{storage_warning}',
                     %s::jsonb,
                     true


### PR DESCRIPTION
## Problem

Resuming a scan (status set back to `pending`) crashes the engine the next time it needs to record a storage warning:

```
psycopg.errors.InvalidParameterValue: cannot set path in scalar
```

The backend resets the scan's `reasoning` column with a plain JS `null` via Prisma, which stores **JSON null** (a jsonb scalar) rather than SQL `NULL`. The engine's `set_scan_storage_warning` then runs `jsonb_set(coalesce(reasoning, '{}'::jsonb), ...)` — but `coalesce` only catches SQL `NULL`, so `jsonb_set` operates on the scalar and Postgres raises the error above, failing the scan.

## Fix

- **backend** (`src/routes/scans.js`): write `Prisma.DbNull` instead of `null` so the column is a true SQL `NULL`.
- **engine** (`open_kritt_engine/db.py`): harden `set_scan_storage_warning` to treat any non-object `reasoning` value as `{}`, so a stray scalar already in the database can never fail a scan.

## Notes for reviewers

- Rows written before this fix may still hold a scalar `reasoning`; the engine-side hardening makes those harmless, but they can also be cleaned up with:
  ```sql
  UPDATE public.scans SET reasoning = NULL
  WHERE reasoning IS NOT NULL AND jsonb_typeof(reasoning) <> 'object';
  ```
- Other `reasoning` readers/writers (`clear_scan_storage_warning`, `_completed_scan_reasoning_sql`, the rate-limit retry path) are already scalar-safe: `?` returns false and `->>'` returns NULL on scalars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H1onPsYCaRJDjQJMm1Mwx