### PR TITLE
docs: fix subject-verb agreement 'uses' to 'use' in threat-model.md

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -24,7 +24,7 @@ target repo (+ dependency repos), builds a workspace, and runs each workflow ste
 an AI **harness** (`codex` / `claude-code`), which sends repository content to the
 **configured model/provider endpoint** → results are written back to Postgres → UI.
 
-Workflow and post-script generation uses a separate Postgres queue. The natural-language
+Workflow and post-script generation use a separate Postgres queue. The natural-language
 request is sent to the selected provider, but the generation harness runs without model
 tools or repository access. Postgres retains the request and stores only a validated
 draft or safe failure details, not invalid raw model output; the backend validates


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/threat-model.md` (line 27).

## Problem

Subject-verb disagreement: the compound subject "Workflow and post-script generation" takes the singular verb "uses"; it should be the plural "use".

The problematic text:

```markdown
Workflow and post-script generation uses a separate Postgres queue.
```

## Fix

Replaced with:

```markdown
Workflow and post-script generation use a separate Postgres queue.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text