### PR TITLE
docs: fix ambiguous subject-verb agreement in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,7 @@ mind when self-hosting:
   and direct internet access. Use a dedicated VM or Docker host and treat scanned
   repositories and model output as untrusted input.
 - **Secrets.** Model/provider API keys and `GITHUB_TOKEN` live in your gitignored `.env`;
-  provider logins live under `.data/`. Accounts gives the backend write access to those
+  provider logins live under `.data/`. The Accounts feature gives the backend write access to those
   stores so changes persist. Scope tokens minimally and rotate them. Never commit
   secrets; the repo ships a `gitleaks` pre-commit hook to help.
 - **Data egress.** Scans send repository content to whichever model/provider endpoint


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `SECURITY.md` (line 64).

## Problem

Subject-verb disagreement: "Accounts" is plural in form but takes the singular verb "gives". Adding "The" and "feature" clarifies the singular intent.

The problematic text:

```markdown
Accounts gives the backend write access to those stores so changes persist.
```

## Fix

Replaced with:

```markdown
The Accounts feature gives the backend write access to those stores so changes persist.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text