### PR TITLE
feat(providers): add OpenCode Zen as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,12 +109,13 @@ ENGINE_CODEX_AUTO_UPDATE=false
 ENGINE_CODEX_UPDATE_INTERVAL_SECONDS=86400
 ENGINE_CODEX_UPDATE_TIMEOUT_SECONDS=120
 # Configure model access primarily from Accounts or with `./kritt setup`.
-# Accounts writes OpenRouter changes back here for future runs. A GitHub token
-# alone cannot run scans.
+# Accounts writes OpenRouter and OpenCode Zen changes back here for future
+# runs. A GitHub token alone cannot run scans.
 CODEX_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
+OPENCODE_API_KEY=
 CODEX_MODEL_PROVIDER=
 # Optional: required only when scanning private GitHub repositories.
 GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ over their prompts, workflows, model providers, and infrastructure.
 - **Prioritize results** — apply custom severity rankers, a consistent finding schema,
   and automatic de-duplication.
 - **Bring your own model access** — use a Codex login or connect through OpenAI,
-  Anthropic, or OpenRouter.
+  Anthropic, OpenRouter, or OpenCode Zen.
 
 > **Built from real security research.** The Kritt team has earned over **$1,500,000 in
 > bug-bounty payouts** under the researcher name **Blockian**

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -152,7 +152,7 @@ model Scan {
   agentSkillIds BigInt[] @default([]) @map("agent_skill_ids")
   configuration Json     @map("configuration")
   model         String
-  modelProvider String  @default("openrouter") @map("model_provider") // codex, claude, openrouter
+  modelProvider String  @default("openrouter") @map("model_provider") // codex, claude, openrouter, opencode
   harness       String
   thinkingEffort String? @map("thinking_effort") // default, low, medium, high, xhigh, max, ultra
   // Optional depth-keyed model tuples. The top-level tuple remains the fallback

--- a/backend/src/lib/accounts.js
+++ b/backend/src/lib/accounts.js
@@ -7,7 +7,7 @@ import { CLAUDE_HOME } from './providerLogins.js';
 const EXECUTOR_VIEW_URL = process.env.EXECUTOR_VIEW_URL || 'http://executor-view:8090';
 const EXECUTOR_VIEW_INTERNAL_TOKEN_FILE =
   process.env.EXECUTOR_VIEW_INTERNAL_TOKEN_FILE || '/executor-auth/internal-token';
-const ACCOUNT_PROVIDER_IDS = ['codex', 'claude', 'openrouter'];
+const ACCOUNT_PROVIDER_IDS = ['codex', 'claude', 'openrouter', 'opencode'];
 const EXECUTOR_ACCOUNT_TIMEOUT_MS = 180000;
 const ACCOUNT_STATUS_KINDS = new Set(['available', 'limited', 'stale', 'expired', 'warning', 'missing']);
 

--- a/backend/src/lib/constants.js
+++ b/backend/src/lib/constants.js
@@ -71,7 +71,7 @@ export const SCAN_STATUSES = [
 export const THINKING_EFFORTS = ['default', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
 export const DEFAULT_THINKING_EFFORT = 'medium';
 
-export const MODEL_PROVIDERS = ['codex', 'claude', 'openrouter'];
+export const MODEL_PROVIDERS = ['codex', 'claude', 'openrouter', 'opencode'];
 export const DEFAULT_MODEL_PROVIDER = 'openrouter';
 
 export const HARNESSES = ['codex', 'claude-code', 'cursor'];
@@ -84,7 +84,12 @@ export const MODEL_PROVIDER_HARNESSES = {
   codex: ['codex'],
   claude: ['claude-code'],
   openrouter: ['codex', 'claude-code'],
+  opencode: ['codex', 'claude-code'],
 };
+// OpenRouter's and OpenCode Zen's discovered catalogs are advisory: exact
+// model IDs remain accepted through a free-text input even when the cached
+// catalog is unavailable or incomplete.
+export const FREE_TEXT_MODEL_INPUT_PROVIDERS = ['openrouter', 'opencode'];
 export const HARNESS_THINKING_EFFORTS = {
   codex: ['default', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
   'claude-code': ['default', 'low', 'medium', 'high', 'xhigh', 'max'],

--- a/backend/src/lib/modelCatalog.js
+++ b/backend/src/lib/modelCatalog.js
@@ -1,4 +1,4 @@
-import { MODEL_PROVIDERS, THINKING_EFFORTS } from './constants.js';
+import { FREE_TEXT_MODEL_INPUT_PROVIDERS, MODEL_PROVIDERS, THINKING_EFFORTS } from './constants.js';
 
 const SAFE_MODEL_NOTE_URLS = new Set(['https://chatgpt.com/cyber']);
 
@@ -118,10 +118,11 @@ export function modelCatalogEntry(provider, catalog) {
   const lastError = catalogValue(catalog, 'lastError', 'last_error');
   const defaultIsMissing = !configuredDefault || !defaultModel;
   // A failed refresh must not erase a previously valid bounded catalog. Without
-  // one, catalog-backed suggestions remain unavailable; OpenRouter still accepts
-  // explicit model IDs through its text input and selection validation policy.
+  // one, catalog-backed suggestions remain unavailable; free-text providers still
+  // accept explicit model IDs through their text input and selection validation policy.
   const status = models.length > 0 && !defaultIsMissing ? 'ready' : hasText(lastError) ? 'unavailable' : 'loading';
-  return { provider, input: provider === 'openrouter' ? 'text' : 'select', models, defaultModel, status };
+  const input = FREE_TEXT_MODEL_INPUT_PROVIDERS.includes(provider) ? 'text' : 'select';
+  return { provider, input, models, defaultModel, status };
 }
 
 export function buildModelCatalogResponse(configuredProviders, catalogs = []) {

--- a/backend/src/lib/modelProviders.js
+++ b/backend/src/lib/modelProviders.js
@@ -6,6 +6,7 @@ const PROVIDER_CREDENTIALS = {
   codex: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
   claude: ['ANTHROPIC_API_KEY'],
   openrouter: ['OPENROUTER_API_KEY'],
+  opencode: ['OPENCODE_API_KEY'],
 };
 
 function hasValue(value) {

--- a/backend/src/lib/modelSelection.js
+++ b/backend/src/lib/modelSelection.js
@@ -1,4 +1,5 @@
 import { prisma } from '../db.js';
+import { FREE_TEXT_MODEL_INPUT_PROVIDERS } from './constants.js';
 import { modelCatalogEntry } from './modelCatalog.js';
 import { isModelProviderConfigured } from './modelProviders.js';
 import { ValidationError } from './validation.js';
@@ -15,7 +16,7 @@ export async function assertModelSelectionAvailable(
     throw new ValidationError([{ field: 'model_provider', message: 'The selected model provider is not configured.' }]);
   }
 
-  if (modelProvider === 'openrouter') return;
+  if (FREE_TEXT_MODEL_INPUT_PROVIDERS.includes(modelProvider)) return;
 
   const catalog = modelCatalogEntry(modelProvider, await getCatalog(modelProvider));
   if (catalog.status !== 'ready') {

--- a/backend/src/lib/providerCredentials.js
+++ b/backend/src/lib/providerCredentials.js
@@ -31,9 +31,16 @@ export const PROVIDER_DEFINITIONS = {
     description: 'OpenRouter-compatible models through a project API key.',
     management: 'api_key',
   },
+  opencode: {
+    label: 'OpenCode Zen',
+    envKeys: ['OPENCODE_API_KEY'],
+    credentialLabel: 'OpenCode Zen API key',
+    description: 'OpenCode Zen-hosted Claude and GPT-5.x-codex models through a project API key.',
+    management: 'api_key',
+  },
 };
 
-const MANAGED_CREDENTIAL_PROVIDERS = new Set(['openrouter']);
+const MANAGED_CREDENTIAL_PROVIDERS = new Set(['openrouter', 'opencode']);
 
 const MAX_CREDENTIAL_LENGTH = 16 * 1024;
 let writeQueue = Promise.resolve();
@@ -107,7 +114,7 @@ function queuedWrite(operation) {
 
 export function validateProviderCredential(provider, credential) {
   if (!MANAGED_CREDENTIAL_PROVIDERS.has(provider)) {
-    return { field: 'provider', message: 'Only OpenRouter uses an API key in Accounts.' };
+    return { field: 'provider', message: 'This provider does not use an API key in Accounts.' };
   }
   if (typeof credential !== 'string' || !credential.trim()) {
     return { field: 'credential', message: 'Enter an API key.' };
@@ -215,8 +222,8 @@ export function providerCredentialStatuses({
       management: definition.management,
       configured,
       source,
-      canManage: definition.management === 'login' || id === 'openrouter',
-      canRemove: id === 'openrouter' && (managedCredential || environmentCredential),
+      canManage: definition.management === 'login' || MANAGED_CREDENTIAL_PROVIDERS.has(id),
+      canRemove: MANAGED_CREDENTIAL_PROVIDERS.has(id) && (managedCredential || environmentCredential),
       managed: managedCredential,
     };
   });

--- a/backend/test/accounts.test.js
+++ b/backend/test/accounts.test.js
@@ -58,7 +58,7 @@ test('executor account integration loads each provider independently with the di
 
   assert.deepEqual(
     accounts.providers.map((provider) => provider.kind),
-    ['codex', 'claude', 'openrouter']
+    ['codex', 'claude', 'openrouter', 'opencode']
   );
   assert.deepEqual(
     requests.map((request) => request.url),
@@ -66,6 +66,7 @@ test('executor account integration loads each provider independently with the di
       'http://executor-view:8090/api/accounts/codex?refresh=1',
       'http://executor-view:8090/api/accounts/claude?refresh=1',
       'http://executor-view:8090/api/accounts/openrouter?refresh=1',
+      'http://executor-view:8090/api/accounts/opencode?refresh=1',
     ]
   );
   assert.ok(requests.every((request) => request.options.headers.Authorization === 'Bearer backend-only-token'));

--- a/backend/test/generations.test.js
+++ b/backend/test/generations.test.js
@@ -291,7 +291,7 @@ test('generation polling returns 404 for an unknown id', async () => {
   assert.deepEqual(response.body, { error: 'Generation not found.' });
 });
 
-test('shared model availability enforces native catalogs and leaves OpenRouter unrestricted', async () => {
+test('shared model availability enforces native catalogs and leaves OpenRouter and OpenCode Zen unrestricted', async () => {
   await assert.rejects(
     () =>
       assertModelSelectionAvailable(
@@ -324,6 +324,19 @@ test('shared model availability enforces native catalogs and leaves OpenRouter u
         getCatalog: async () => ({
           models: [{ id: 'vendor/catalog-suggestion', thinkingEfforts: ['medium'] }],
           defaultModel: 'vendor/catalog-suggestion',
+        }),
+      }
+    )
+  );
+
+  await assert.doesNotReject(() =>
+    assertModelSelectionAvailable(
+      { modelProvider: 'opencode', model: 'custom-not-in-catalog' },
+      {
+        providerConfigured: async () => true,
+        getCatalog: async () => ({
+          models: [{ id: 'gpt-5.1-codex', thinkingEfforts: ['default'] }],
+          defaultModel: 'gpt-5.1-codex',
         }),
       }
     )

--- a/backend/test/modelCatalog.test.js
+++ b/backend/test/modelCatalog.test.js
@@ -191,6 +191,7 @@ test('cached model lookup identifies exact catalog entries', () => {
   assert.equal(isCachedModel('claude', 'claude-opus-4-8', null), true);
   assert.equal(isCachedModel('claude', 'claude-sonnet-4', null), false);
   assert.equal(isCachedModel('openrouter', 'any/provider-model', null), false);
+  assert.equal(isCachedModel('opencode', 'gpt-5.1-codex', null), false);
 });
 
 test('a last refresh error retains a previously valid cached catalog', () => {
@@ -248,6 +249,49 @@ test('OpenRouter exposes cached suggestions while keeping free-text input', () =
   assert.equal(isCachedModel('openrouter', 'custom/not-in-catalog', catalog), false);
   assert.equal(
     buildModelCatalogResponse(['openrouter'], [{ provider: 'openrouter', models: [], lastError: 'refresh failed' }])
+      .providers[0].status,
+    'unavailable'
+  );
+});
+
+test('OpenCode Zen exposes cached suggestions while keeping free-text input', () => {
+  const catalog = {
+    provider: 'opencode',
+    models: [
+      { id: 'gpt-5.1-codex', label: 'gpt-5.1-codex', thinkingEfforts: ['default'] },
+      { id: 'claude-opus-5', thinkingEfforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
+    ],
+    defaultModel: 'gpt-5.1-codex',
+  };
+
+  assert.deepEqual(buildModelCatalogResponse(['opencode'], [catalog]), {
+    providers: [
+      {
+        provider: 'opencode',
+        input: 'text',
+        models: [
+          {
+            id: 'gpt-5.1-codex',
+            label: 'gpt-5.1-codex',
+            thinkingEfforts: ['default'],
+            isDefault: true,
+          },
+          {
+            id: 'claude-opus-5',
+            label: 'claude-opus-5',
+            thinkingEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+            isDefault: false,
+          },
+        ],
+        defaultModel: 'gpt-5.1-codex',
+        status: 'ready',
+      },
+    ],
+  });
+  assert.equal(isCachedModel('opencode', 'gpt-5.1-codex', catalog), true);
+  assert.equal(isCachedModel('opencode', 'custom-not-in-catalog', catalog), false);
+  assert.equal(
+    buildModelCatalogResponse(['opencode'], [{ provider: 'opencode', models: [], lastError: 'refresh failed' }])
       .providers[0].status,
     'unavailable'
   );

--- a/backend/test/modelProviders.test.js
+++ b/backend/test/modelProviders.test.js
@@ -10,10 +10,12 @@ const PROVIDER_ENV_KEYS = [
   'OPENAI_API_KEY',
   'ANTHROPIC_API_KEY',
   'OPENROUTER_API_KEY',
+  'OPENCODE_API_KEY',
   'OPEN_KRITT_CODEX_API_KEY_CONFIGURED',
   'OPEN_KRITT_OPENAI_API_KEY_CONFIGURED',
   'OPEN_KRITT_ANTHROPIC_API_KEY_CONFIGURED',
   'OPEN_KRITT_OPENROUTER_API_KEY_CONFIGURED',
+  'OPEN_KRITT_OPENCODE_API_KEY_CONFIGURED',
   'OPEN_KRITT_CODEX_LOGIN_CONFIGURED',
   'CODEX_LOGIN_CONFIGURED',
 ];
@@ -44,10 +46,11 @@ test('configuredModelProviders returns canonical providers configured by presenc
       OPEN_KRITT_OPENAI_API_KEY_CONFIGURED: '1',
       OPEN_KRITT_ANTHROPIC_API_KEY_CONFIGURED: '1',
       OPEN_KRITT_OPENROUTER_API_KEY_CONFIGURED: '1',
+      OPEN_KRITT_OPENCODE_API_KEY_CONFIGURED: '1',
     },
   });
 
-  assert.deepEqual(providers, ['codex', 'claude', 'openrouter']);
+  assert.deepEqual(providers, ['codex', 'claude', 'openrouter', 'opencode']);
 });
 
 test('configuredModelProviders does not mistake a stale Codex login marker for credentials', () => {

--- a/backend/test/providerCredentials.test.js
+++ b/backend/test/providerCredentials.test.js
@@ -110,6 +110,40 @@ test('credential validation accepts only a single-line OpenRouter key', () => {
   assert.equal(validateProviderCredential('openrouter', 'one\ntwo').field, 'credential');
 });
 
+test('credential validation accepts only a single-line OpenCode Zen key', () => {
+  assert.equal(validateProviderCredential('opencode', 'valid-key'), null);
+  assert.equal(validateProviderCredential('opencode', ' ').field, 'credential');
+  assert.equal(validateProviderCredential('opencode', 'one\ntwo').field, 'credential');
+});
+
+test('OpenCode Zen managed credentials are saved privately, overridable, and removable', async (t) => {
+  const credentialsPath = await temporaryCredentialPath(t);
+  const environmentFilePath = join(dirname(credentialsPath), '.env');
+  await writeFile(environmentFilePath, 'KEEP=value\nOPENCODE_API_KEY=\n');
+  await saveManagedProviderCredential('opencode', 'opencode-secret', {
+    credentialsPath,
+    environmentFilePath,
+  });
+
+  assert.deepEqual(readManagedCredentialsSync(credentialsPath), { opencode: 'opencode-secret' });
+  assert.deepEqual(parseEnvironmentText(await readFile(environmentFilePath, 'utf8')), {
+    KEEP: 'value',
+    OPENCODE_API_KEY: 'opencode-secret',
+  });
+
+  const opencode = providerCredentialStatuses({ env: {}, credentialsPath }).find(
+    (provider) => provider.id === 'opencode'
+  );
+  assert.equal(opencode.source, 'managed_api_key');
+  assert.equal(opencode.canManage, true);
+  assert.equal(opencode.canRemove, true);
+  assert.equal(JSON.stringify(opencode).includes('opencode-secret'), false);
+
+  assert.equal(await removeManagedProviderCredential('opencode', { credentialsPath, environmentFilePath }), true);
+  assert.deepEqual(readManagedCredentialsSync(credentialsPath), {});
+  assert.equal(parseEnvironmentText(await readFile(environmentFilePath, 'utf8')).OPENCODE_API_KEY, '');
+});
+
 test('provider status recognizes Codex and Claude login homes', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'open-kritt-provider-logins-'));
   t.after(() => rm(directory, { recursive: true, force: true }));

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -465,6 +465,8 @@ test('validateScan enforces model provider and harness compatibility after norma
   assert.equal(validateScan({ ...base, model_provider: 'claude', harness: 'claude-code' }).modelProvider, 'claude');
   assert.equal(validateScan({ ...base, model_provider: 'openrouter', harness: 'codex' }).harness, 'codex');
   assert.equal(validateScan({ ...base, model_provider: 'openrouter', harness: 'claude-code' }).harness, 'claude-code');
+  assert.equal(validateScan({ ...base, model_provider: 'opencode', harness: 'codex' }).harness, 'codex');
+  assert.equal(validateScan({ ...base, model_provider: 'opencode', harness: 'claude-code' }).harness, 'claude-code');
   assert.deepEqual(
     validateScan({
       ...base,

--- a/docs-site/ai-provider-setup/opencode-zen.mdx
+++ b/docs-site/ai-provider-setup/opencode-zen.mdx
@@ -1,0 +1,99 @@
+---
+title: "OpenCode Zen"
+description: "Create an OpenCode Zen API key and access its curated Claude and GPT-5.x-codex models."
+---
+
+The **OpenCode Zen** provider uses `OPENCODE_API_KEY` to route models through
+[OpenCode Zen](https://opencode.ai/docs/zen/), a curated AI gateway. Unlike OpenRouter,
+OpenCode Zen is not a single unified gateway: it exposes an Anthropic-compatible endpoint
+for its Claude and Qwen models, and a separate OpenAI Responses-API endpoint for its
+GPT-5.x/GPT-5.x-codex models. open·kritt routes each harness to the matching endpoint —
+see [Model compatibility](#model-compatibility) below before choosing a harness and model.
+
+After the key is configured, the engine periodically refreshes a searchable model catalog
+from OpenCode Zen's `/v1/models` endpoint. That endpoint returns only model IDs (no
+display names or reasoning metadata), so the cached catalog is a plainer list of exact
+IDs than OpenRouter's.
+
+## Create and configure the key
+
+<Steps>
+  <Step title="Create an OpenCode Zen account">
+    Sign in at [opencode.ai](https://opencode.ai/auth) and add billing details. OpenCode
+    Zen is pay-per-use; several models are free.
+  </Step>
+  <Step title="Copy your API key">
+    Copy the API key shown after sign-in.
+  </Step>
+  <Step title="Save it in open·kritt">
+    Run `./kritt setup`, choose **OpenCode Zen API key**, and paste the key into the
+    hidden input. The CLI writes it to `OPENCODE_API_KEY` in `.env`. You can also add or
+    replace it from the running application's **Accounts** page.
+  </Step>
+  <Step title="Start or recreate the stack">
+    ```bash
+    ./kritt start
+    ```
+
+    Stop an already-running attached stack with Ctrl+C first.
+  </Step>
+  <Step title="Choose a harness and model">
+    Pick the harness that matches the model family you want (see below), then search the
+    OpenCode Zen model picker in the scan or generation form, or enter an exact model ID
+    such as `claude-opus-5` or `gpt-5.1-codex` as a custom value.
+  </Step>
+</Steps>
+
+## Model compatibility
+
+OpenCode Zen's model families are split across two wire-incompatible endpoints, and
+open·kritt only speaks the two protocols its existing harnesses already support:
+
+- The **Claude Code** harness reaches OpenCode Zen's Anthropic-compatible endpoint, which
+  serves its `claude-*` and `qwen*` model IDs (for example `claude-opus-5`,
+  `claude-sonnet-5`, `qwen3.7-max`).
+- The **Codex** harness reaches OpenCode Zen's OpenAI Responses-API endpoint, which
+  serves its `gpt-*` model family — including the `gpt-5.x-codex` models OpenCode Zen
+  recommends for coding agents (for example `gpt-5.1-codex`, `gpt-5-codex`).
+
+Picking the wrong pair (for example the Claude Code harness with a `gpt-*` model, or the
+Codex harness with a `claude-*`/`qwen*` model) fails fast with a clear configuration
+error instead of an opaque upstream HTTP failure.
+
+OpenCode Zen also offers other model families — Grok, DeepSeek, GLM, Kimi, MiniMax,
+Gemini, and several free models — over its OpenAI-compatible `/v1/chat/completions`
+endpoint and Google-specific paths. Neither harness speaks those wire formats today, so
+those models are filtered out of the discovered catalog and are not usable through
+open·kritt yet.
+
+## Catalog refresh and fallback
+
+The engine refreshes the OpenCode Zen catalog in the background and stores only the
+model IDs from families listed above. While the first refresh is still running, the
+forms may show the catalog as loading. A successful refresh replaces the cached choices.
+
+If a later refresh fails, open·kritt keeps the last usable cached catalog. If no
+successful catalog has been cached yet, model discovery is shown as unavailable; check
+the engine logs and the configured key, then retry. You can still use an exact custom
+model ID as the compatibility escape hatch — the discovered catalog is a convenience,
+not an allow-list.
+
+## Verify and troubleshoot
+
+- `./kritt setup` should show **OpenCode Zen API key present**.
+- The create and generation forms should list **OpenCode Zen** and load a searchable
+  model catalog. An exact custom ID can also be entered when needed.
+- If the catalog remains in a loading or unavailable state, inspect
+  `docker compose logs engine` and confirm the configured API key can list models at
+  `https://opencode.ai/zen/v1/models`.
+- A `401` usually means the key is invalid or revoked.
+- A "not reachable through the Claude Code harness" or "not reachable through the Codex
+  harness" error means the selected model and harness are mismatched — see
+  [Model compatibility](#model-compatibility) above and switch either the model or the
+  harness.
+- A model-not-found error usually means the identifier is misspelled or belongs to one
+  of the unsupported model families listed above.
+
+Next: configure [Codex](/ai-provider-setup/codex), [Claude Code](/ai-provider-setup/claude-code),
+[OpenRouter](/ai-provider-setup/openrouter), or learn how to choose a
+[model and harness](/scans/model-and-harness).

--- a/docs-site/ai-provider-setup/overview.mdx
+++ b/docs-site/ai-provider-setup/overview.mdx
@@ -11,6 +11,7 @@ between them per run, but a single working provider is enough to start.
 | **Codex** | ChatGPT/Codex login or an OpenAI Platform key | Account-specific picker |
 | **Claude** | Claude subscription login or `ANTHROPIC_API_KEY` | Subscription aliases or account-specific picker |
 | **OpenRouter** | `OPENROUTER_API_KEY` | Searchable authenticated catalog, with an exact-ID fallback |
+| **OpenCode Zen** | `OPENCODE_API_KEY` | Searchable authenticated catalog, with an exact-ID fallback |
 
 <CardGroup cols={2}>
   <Card title="Codex" icon="terminal" href="/ai-provider-setup/codex">
@@ -21,6 +22,9 @@ between them per run, but a single working provider is enough to start.
   </Card>
   <Card title="OpenRouter" icon="route" href="/ai-provider-setup/openrouter">
     Use one key to access compatible models through OpenRouter.
+  </Card>
+  <Card title="OpenCode Zen" icon="cloud" href="/ai-provider-setup/opencode-zen">
+    Use one key to access OpenCode Zen's curated Claude and GPT-5.x-codex models.
   </Card>
 </CardGroup>
 
@@ -36,9 +40,9 @@ between them per run, but a single working provider is enough to start.
   </Step>
   <Step title="Choose one access method">
     Select **Codex login**, **OpenAI API key**, **Codex API key**, **Anthropic API key**,
-    or **OpenRouter API key**. Follow the provider guide above to obtain the correct
-    credential. The CLI configures keys and Codex login; Claude subscription login is
-    available from the running application's **Accounts** page.
+    **OpenRouter API key**, or **OpenCode Zen API key**. Follow the provider guide above
+    to obtain the correct credential. The CLI configures keys and Codex login; Claude
+    subscription login is available from the running application's **Accounts** page.
   </Step>
   <Step title="Start or recreate the stack">
     ```bash
@@ -61,7 +65,7 @@ API keys configured by the CLI are written to the repository's `.env` file. Code
 are stored under `ENGINE_CODEX_ACCOUNTS_HOST`, which defaults to
 `./.data/codex-accounts`; a Claude login is stored under `ENGINE_CLAUDE_HOME`, which
 defaults to `./.data/claude`. The Accounts page keeps Codex account paths and its
-OpenRouter key synchronized with `.env`, and mirrors the OpenRouter key under
+OpenRouter and OpenCode Zen keys synchronized with `.env`, and mirrors those keys under
 `.data/engine/credentials` so running services see changes immediately. `.env` and
 `.data/` are ignored by Git.
 
@@ -82,5 +86,5 @@ engine receives the actual credential when it starts a model harness.
 </Note>
 
 Next: configure the recommended [Codex provider](/ai-provider-setup/codex),
-[Claude Code](/ai-provider-setup/claude-code), or
-[OpenRouter](/ai-provider-setup/openrouter).
+[Claude Code](/ai-provider-setup/claude-code), [OpenRouter](/ai-provider-setup/openrouter),
+or [OpenCode Zen](/ai-provider-setup/opencode-zen).

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -30,7 +30,8 @@
           "ai-provider-setup/overview",
           "ai-provider-setup/codex",
           "ai-provider-setup/claude-code",
-          "ai-provider-setup/openrouter"
+          "ai-provider-setup/openrouter",
+          "ai-provider-setup/opencode-zen"
         ]
       },
       {

--- a/engine/open_kritt_engine/generation.py
+++ b/engine/open_kritt_engine/generation.py
@@ -49,7 +49,7 @@ POST_SCRIPT_MARKDOWN_OUTPUT_KEYS = frozenset({"_reserved_report", "_reserved_poc
 POST_SCRIPT_CHIP_PREFIX = "_chip_"
 WORKFLOW_FIELD_TYPES = ("string", "number", "boolean", "array", "object")
 POST_SCRIPT_FIELD_TYPES = WORKFLOW_FIELD_TYPES
-MODEL_PROVIDERS = frozenset({"codex", "claude", "openrouter"})
+MODEL_PROVIDERS = frozenset({"codex", "claude", "openrouter", "opencode"})
 THINKING_EFFORTS = frozenset({"default", "low", "medium", "high", "xhigh", "max", "ultra"})
 GENERATION_REQUEST_MAX_LENGTH = 20_000
 MODEL_ID_MAX_LENGTH = 200
@@ -62,6 +62,7 @@ MODEL_PROVIDER_HARNESSES = {
     "codex": frozenset({"codex"}),
     "claude": frozenset({"claude-code"}),
     "openrouter": frozenset({"codex", "claude-code"}),
+    "opencode": frozenset({"codex", "claude-code"}),
 }
 HARNESS_THINKING_EFFORTS = {
     "codex": frozenset({"default", "low", "medium", "high", "xhigh", "max", "ultra"}),
@@ -100,6 +101,7 @@ GENERATION_PROVIDER_ENV_KEYS = {
     "codex": frozenset({"CODEX_API_KEY", "OPENAI_API_KEY", "CODEX_HOME"}),
     "claude": frozenset({"ANTHROPIC_API_KEY"}),
     "openrouter": frozenset({"OPENROUTER_API_KEY"}),
+    "opencode": frozenset({"OPENCODE_API_KEY"}),
 }
 
 

--- a/engine/open_kritt_engine/harnesses.py
+++ b/engine/open_kritt_engine/harnesses.py
@@ -160,6 +160,8 @@ TOOL_FREE_CODEX_DISABLED_FEATURES = (
 OPENROUTER_CLAUDE_BASE_URL = "https://openrouter.ai/api"
 OPENROUTER_CURSOR_BASE_URL = "https://openrouter.ai/api/v1/cursor"
 OPENROUTER_CODEX_BASE_URL = "https://openrouter.ai/api/v1"
+OPENCODE_CLAUDE_BASE_URL = "https://opencode.ai/zen"
+OPENCODE_CODEX_BASE_URL = "https://opencode.ai/zen/v1"
 OPENROUTER_MODEL_ALIASES = {
     "glm-5.2": "z-ai/glm-5.2",
     "grok-4.5": "x-ai/grok-4.5",
@@ -168,8 +170,20 @@ CLAUDE_MODEL_ALIASES = {
     "opus-4.7": "claude-opus-4-7",
     "opus-4.8": "claude-opus-4-8",
 }
+# OpenCode Zen has no single unified gateway: its Anthropic-compatible endpoint
+# only serves claude-*/qwen* ids, and its OpenAI Responses-API endpoint only
+# serves gpt-* ids. Harness and model family are coupled for this provider,
+# unlike OpenRouter which translates any model for either harness.
+CLAUDE_GATEWAY_PROVIDERS = {
+    "openrouter": ("OPENROUTER_API_KEY", OPENROUTER_CLAUDE_BASE_URL),
+    "opencode": ("OPENCODE_API_KEY", OPENCODE_CLAUDE_BASE_URL),
+}
+CODEX_GATEWAY_PROVIDERS = {
+    "openrouter": {"name": "OpenRouter", "base_url": OPENROUTER_CODEX_BASE_URL, "env_key": "OPENROUTER_API_KEY"},
+    "opencode": {"name": "OpenCode Zen", "base_url": OPENCODE_CODEX_BASE_URL, "env_key": "OPENCODE_API_KEY"},
+}
 DEFAULT_MODEL_PROVIDER = "openrouter"
-MODEL_PROVIDERS = {"codex", "claude", "openrouter"}
+MODEL_PROVIDERS = {"codex", "claude", "openrouter", "opencode"}
 CLAUDE_WORKSPACE_SYSTEM_PROMPT = (
     "Use only files under the current working directory and dependency paths listed in WORKSPACE.json. "
     "Do not search from filesystem root (/), /data, /root, /home, or other global paths. "
@@ -504,7 +518,8 @@ def _classify_harness_output(output: str, *, provider: str | None = None) -> str
             "quota temporarily exceeded",
         )
     )
-    if rate_limit_signal or _has_http_status(normalized, 429) or (provider == "openrouter" and quota_signal):
+    gateway_quota_signal = provider in {"openrouter", "opencode"} and quota_signal
+    if rate_limit_signal or _has_http_status(normalized, 429) or gateway_quota_signal:
         return "rate_limited"
     if quota_signal:
         return "quota_exceeded"
@@ -609,12 +624,16 @@ def _classified_harness_error(
     )
 
 
-def _uses_openrouter(cmd: list[str], env: dict[str, str]) -> bool:
+def _gateway_provider(cmd: list[str], env: dict[str, str]) -> str | None:
     base_urls = (env.get("ANTHROPIC_BASE_URL"), env.get("OPENAI_BASE_URL"))
-    if any("openrouter.ai" in str(value).lower() for value in base_urls if value):
-        return True
+    for provider, host in (("openrouter", "openrouter.ai"), ("opencode", "opencode.ai")):
+        if any(host in str(value).lower() for value in base_urls if value):
+            return provider
     command = " ".join(str(part) for part in cmd).lower()
-    return "openrouter.ai" in command or 'model_provider="openrouter"' in command
+    for provider, host in (("openrouter", "openrouter.ai"), ("opencode", "opencode.ai")):
+        if host in command or f'model_provider="{provider}"' in command:
+            return provider
+    return None
 
 
 def _run_process(cmd, prompt, cwd, timeout, env=None):
@@ -657,7 +676,7 @@ def _run_process(cmd, prompt, cwd, timeout, env=None):
             harness=harness,
             exit_code=proc.returncode,
             output_artifact=_process_output(proc),
-            provider="openrouter" if _uses_openrouter(cmd, process_env) else None,
+            provider=_gateway_provider(cmd, process_env),
         )
     return proc
 
@@ -824,6 +843,7 @@ def _scan_docker_command(cmd: list[str], repo_dir: str, env: dict[str, str]) -> 
         "CODEX_API_KEY",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
+        "OPENCODE_API_KEY",
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_API_KEY",
@@ -899,8 +919,8 @@ def codex_cli_model_provider(
     configured = normalize_model_provider(codex_model_provider)
     if selected == "codex":
         return None
-    if selected == "openrouter":
-        return (configured or "openrouter") if allow_tools else "openrouter"
+    if selected in CODEX_GATEWAY_PROVIDERS:
+        return (configured or selected) if allow_tools else selected
     return selected or configured
 
 
@@ -917,8 +937,8 @@ def claude_model_provider(
     model: str, env: dict[str, str] | None = None, model_provider: str | None = None
 ) -> str | None:
     requested_provider = normalize_model_provider(model_provider)
-    if requested_provider == "openrouter":
-        return "openrouter"
+    if requested_provider in CLAUDE_GATEWAY_PROVIDERS:
+        return requested_provider
     if requested_provider:
         return None
     actual_env = env or os.environ
@@ -940,7 +960,7 @@ def _claude_model_name(model: str, env: dict[str, str], model_provider: str | No
 
 def _apply_claude_host_auth_home(env: dict[str, str], provider: str | None) -> dict[str, str]:
     auth_home = env.get("ENGINE_CLAUDE_AUTH_HOME") or os.getenv("ENGINE_CLAUDE_AUTH_HOME")
-    if provider == "openrouter" or not auth_home or _env_enabled("ENGINE_CLAUDE_DOCKER_RUNNER"):
+    if provider in CLAUDE_GATEWAY_PROVIDERS or not auth_home or _env_enabled("ENGINE_CLAUDE_DOCKER_RUNNER"):
         return env
     actual_env = dict(env)
     auth_home = str(Path(auth_home).expanduser())
@@ -959,11 +979,20 @@ def _apply_claude_host_auth_home(env: dict[str, str], provider: str | None) -> d
 
 def _claude_env(env: dict[str, str], model: str, model_provider: str | None = None) -> dict[str, str]:
     actual_env = dict(env)
-    if claude_model_provider(model, actual_env, model_provider) == "openrouter":
-        if not actual_env.get("OPENROUTER_API_KEY"):
-            raise HarnessError("OPENROUTER_API_KEY is required when model provider is openrouter")
-        actual_env["ANTHROPIC_BASE_URL"] = actual_env.get("ANTHROPIC_BASE_URL") or OPENROUTER_CLAUDE_BASE_URL
-        actual_env["ANTHROPIC_AUTH_TOKEN"] = actual_env.get("ANTHROPIC_AUTH_TOKEN") or actual_env["OPENROUTER_API_KEY"]
+    provider = claude_model_provider(model, actual_env, model_provider)
+    gateway = CLAUDE_GATEWAY_PROVIDERS.get(provider) if provider else None
+    if gateway:
+        env_key, base_url = gateway
+        if not actual_env.get(env_key):
+            raise HarnessError(f"{env_key} is required when model provider is {provider}")
+        if provider == "opencode" and model.lower().startswith("gpt-"):
+            raise HarnessError(
+                f'Model "{model}" is not reachable through the Claude Code harness on OpenCode Zen; '
+                "use the Codex harness for GPT models.",
+                code="configuration_error",
+            )
+        actual_env["ANTHROPIC_BASE_URL"] = actual_env.get("ANTHROPIC_BASE_URL") or base_url
+        actual_env["ANTHROPIC_AUTH_TOKEN"] = actual_env.get("ANTHROPIC_AUTH_TOKEN") or actual_env[env_key]
         actual_env["ANTHROPIC_API_KEY"] = ""
     return actual_env
 
@@ -1353,6 +1382,12 @@ def codex_exec_command(
     )
     if normalize_model_provider(model_provider) == "openrouter":
         model = OPENROUTER_MODEL_ALIASES.get(model, model)
+    if cli_model_provider == "opencode" and not model.lower().startswith("gpt-"):
+        raise HarnessError(
+            f'Model "{model}" is not reachable through the Codex harness on OpenCode Zen; '
+            "use the Claude Code harness for Claude/Qwen models.",
+            code="configuration_error",
+        )
     command = ["codex"]
     if allow_tools:
         command.append("--search")
@@ -1375,14 +1410,15 @@ def codex_exec_command(
         for feature in TOOL_FREE_CODEX_DISABLED_FEATURES:
             command.extend(["--disable", feature])
     command.extend(["--output-schema", schema_path, "-o", output_path])
-    if not allow_tools and cli_model_provider == "openrouter":
+    gateway = CODEX_GATEWAY_PROVIDERS.get(cli_model_provider) if cli_model_provider else None
+    if not allow_tools and gateway:
         # `--ignore-user-config` removes custom providers along with user
-        # settings. Recreate only OpenRouter's non-secret definition; Codex
+        # settings. Recreate only the gateway's non-secret definition; Codex
         # reads the actual credential from the named environment variable.
-        command.extend(["-c", 'model_providers.openrouter.name="OpenRouter"'])
-        command.extend(["-c", f'model_providers.openrouter.base_url="{OPENROUTER_CODEX_BASE_URL}"'])
-        command.extend(["-c", 'model_providers.openrouter.env_key="OPENROUTER_API_KEY"'])
-        command.extend(["-c", 'model_providers.openrouter.wire_api="responses"'])
+        command.extend(["-c", f'model_providers.{cli_model_provider}.name="{gateway["name"]}"'])
+        command.extend(["-c", f'model_providers.{cli_model_provider}.base_url="{gateway["base_url"]}"'])
+        command.extend(["-c", f'model_providers.{cli_model_provider}.env_key="{gateway["env_key"]}"'])
+        command.extend(["-c", f'model_providers.{cli_model_provider}.wire_api="responses"'])
     if cli_model_provider:
         command.extend(["-c", f"model_provider={json.dumps(cli_model_provider)}"])
     if thinking_effort and thinking_effort != "default":
@@ -1525,7 +1561,11 @@ class CodexHarness:
                     harness="codex",
                     default_code="invalid_output",
                     output_artifact=process_output,
-                    provider="openrouter" if normalize_model_provider(self.model_provider) == "openrouter" else None,
+                    provider=(
+                        normalize_model_provider(self.model_provider)
+                        if normalize_model_provider(self.model_provider) in CODEX_GATEWAY_PROVIDERS
+                        else None
+                    ),
                 ) from payload_error
             return HarnessResult(payload=parsed_payload, usage=usage, codex_session_id=thread_id, output=process_output)
 
@@ -1599,7 +1639,11 @@ class CodexHarness:
                 harness="codex",
                 default_code="invalid_output",
                 output_artifact=process_output,
-                provider="openrouter" if normalize_model_provider(self.model_provider) == "openrouter" else None,
+                provider=(
+                    normalize_model_provider(self.model_provider)
+                    if normalize_model_provider(self.model_provider) in CODEX_GATEWAY_PROVIDERS
+                    else None
+                ),
             ) from payload_error
         return HarnessResult(
             payload=parsed_payload, usage=usage, codex_session_id=thread_id or session_id, output=process_output
@@ -1638,7 +1682,7 @@ class ClaudeHarness:
             "--input-format",
             "text",
             "--output-format",
-            "stream-json" if provider == "openrouter" else "json",
+            "stream-json" if provider in CLAUDE_GATEWAY_PROVIDERS else "json",
             "--append-system-prompt",
             CLAUDE_WORKSPACE_SYSTEM_PROMPT if allow_tools else CLAUDE_GENERATION_SYSTEM_PROMPT,
         ]
@@ -1648,7 +1692,7 @@ class ClaudeHarness:
             # No tools, MCP configuration, or user/project settings are loaded for
             # untrusted generation requests. The response is schema-only text.
             cmd.extend(["--tools", "", "--permission-mode", "dontAsk", "--strict-mcp-config", "--setting-sources", ""])
-        if provider != "openrouter":
+        if provider not in CLAUDE_GATEWAY_PROVIDERS:
             cmd.extend(["--json-schema", json.dumps(_claude_json_schema(schema))])
         else:
             cmd.extend(["--include-partial-messages", "--verbose"])
@@ -1656,14 +1700,14 @@ class ClaudeHarness:
             cmd.extend(["--effort", thinking_effort])
         run_cmd = _scan_docker_command(cmd, repo_dir, actual_env) if allow_tools else cmd
         timeout_seconds = self.timeout_seconds
-        if provider != "openrouter":
+        if provider not in CLAUDE_GATEWAY_PROVIDERS:
             timeout_seconds = claude_oauth_timeout_seconds(
                 actual_env.get(CLAUDE_OAUTH_EXPIRY_ENV),
                 timeout_seconds,
             )
         proc = _run_process(run_cmd, prompt, repo_dir, timeout_seconds, env=actual_env)
         process_output = _process_output(proc)
-        if provider == "openrouter":
+        if provider in CLAUDE_GATEWAY_PROVIDERS:
             try:
                 payload, usage = _extract_json_from_claude_stream(proc.stdout, provider=provider)
             except HarnessError as exc:

--- a/engine/open_kritt_engine/model_catalog.py
+++ b/engine/open_kritt_engine/model_catalog.py
@@ -24,6 +24,14 @@ LOGGER = logging.getLogger("open_kritt_engine")
 ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models/user"
 OPENROUTER_DEFAULT_MODEL_ID = "z-ai/glm-5.2"
+OPENCODE_MODELS_URL = "https://opencode.ai/zen/v1/models"
+OPENCODE_DEFAULT_MODEL_ID = "gpt-5.1-codex"
+# OpenCode Zen serves other model families (Grok, DeepSeek, GLM, Kimi, MiniMax,
+# Gemini, free-tier models) only over wire formats neither the Codex nor Claude
+# Code harness speaks. Filter the catalog down to the families that are
+# actually reachable: claude-*/qwen* via the Anthropic-compatible endpoint,
+# gpt-* via the OpenAI Responses-API endpoint.
+OPENCODE_SUPPORTED_MODEL_RE = re.compile(r"^(claude-|qwen|gpt-)", re.IGNORECASE)
 CATALOG_REFRESH_ERROR = "Unable to refresh the provider model catalog."
 MAX_CATALOG_MODELS = 500
 MAX_CATALOG_PAGES = 10
@@ -440,6 +448,64 @@ def fetch_openrouter_models(api_key: str, timeout_seconds: float) -> tuple[list[
     return models, default_model
 
 
+def _opencode_is_supported_model(model_id: str) -> bool:
+    return bool(OPENCODE_SUPPORTED_MODEL_RE.match(model_id))
+
+
+def _opencode_thinking_efforts(model_id: str) -> list[str]:
+    # OpenCode Zen's /v1/models exposes no reasoning metadata at all. Reuse the
+    # known Anthropic reasoning-effort table for ids that match Anthropic's own
+    # (OpenCode Zen's Claude ids are identical); everything else gets the
+    # engine's implicit default.
+    return list(CLAUDE_MODEL_THINKING_EFFORTS.get(model_id, ("default",)))
+
+
+def fetch_opencode_models(api_key: str, timeout_seconds: float) -> tuple[list[dict[str, Any]], str]:
+    """List the claude-*/qwen*/gpt-* models available on OpenCode Zen."""
+
+    request = Request(
+        OPENCODE_MODELS_URL,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    try:
+        with urlopen(request, timeout=max(1.0, timeout_seconds)) as response:  # noqa: S310 - fixed provider URL
+            raw_payload = response.read(MAX_HTTP_CATALOG_BYTES + 1)
+        if len(raw_payload) > MAX_HTTP_CATALOG_BYTES:
+            raise ModelCatalogError("OpenCode Zen model catalog response was too large")
+        payload = json.loads(raw_payload)
+    except (HTTPError, URLError, OSError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ModelCatalogError("Could not read the OpenCode Zen model catalog") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        raise ModelCatalogError("OpenCode Zen model catalog response was invalid")
+
+    entries: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for raw in payload["data"]:
+        if not isinstance(raw, Mapping):
+            continue
+        model_id = _clean_text(raw.get("id"))
+        if not model_id or model_id in seen_ids or not _opencode_is_supported_model(model_id):
+            continue
+        seen_ids.add(model_id)
+        entries.append(
+            {
+                "model": model_id,
+                "displayName": None,
+                "supportedReasoningEfforts": _opencode_thinking_efforts(model_id),
+                "isDefault": model_id == OPENCODE_DEFAULT_MODEL_ID,
+            }
+        )
+        if len(entries) > MAX_CATALOG_MODELS:
+            candidate = entries.pop()
+            if candidate["isDefault"] and not any(entry["isDefault"] for entry in entries):
+                entries[-1] = candidate
+
+    models, default_model = normalize_catalog_models(entries)
+    if not models:
+        raise ModelCatalogError("OpenCode Zen model catalog was empty")
+    return models, default_model
+
+
 CatalogFetcher = Callable[[], tuple[list[dict[str, Any]], str]]
 
 
@@ -455,6 +521,7 @@ class ModelCatalogRefresher:
         fetch_codex: CatalogFetcher | None = None,
         fetch_anthropic: CatalogFetcher | None = None,
         fetch_openrouter: CatalogFetcher | None = None,
+        fetch_opencode: CatalogFetcher | None = None,
         codex_cli_gate: Any | None = None,
     ):
         self.db = db
@@ -463,6 +530,7 @@ class ModelCatalogRefresher:
         self.fetch_codex = fetch_codex
         self.fetch_anthropic = fetch_anthropic
         self.fetch_openrouter = fetch_openrouter
+        self.fetch_opencode = fetch_opencode
         self.codex_cli_gate = codex_cli_gate
 
     def refresh(self, env: Mapping[str, str] | None = None) -> dict[str, bool]:
@@ -489,6 +557,11 @@ class ModelCatalogRefresher:
                 lambda: fetch_openrouter_models(env["OPENROUTER_API_KEY"], self.timeout_seconds)
             )
             outcomes["openrouter"] = self._refresh_provider("openrouter", fetch_openrouter)
+        if _clean_text(env.get("OPENCODE_API_KEY")):
+            fetch_opencode = self.fetch_opencode or (
+                lambda: fetch_opencode_models(env["OPENCODE_API_KEY"], self.timeout_seconds)
+            )
+            outcomes["opencode"] = self._refresh_provider("opencode", fetch_opencode)
         return outcomes
 
     def _refresh_provider(self, provider: str, fetcher: CatalogFetcher) -> bool:

--- a/engine/open_kritt_engine/provider_credentials.py
+++ b/engine/open_kritt_engine/provider_credentials.py
@@ -8,6 +8,7 @@ from pathlib import Path
 DEFAULT_PROVIDER_CREDENTIALS_PATH = "/credentials/providers.json"
 PROVIDER_ENV_KEYS = {
     "openrouter": "OPENROUTER_API_KEY",
+    "opencode": "OPENCODE_API_KEY",
 }
 MAX_CREDENTIAL_FILE_BYTES = 1024 * 1024
 _CREDENTIAL_WRITE_LOCK = threading.Lock()
@@ -37,6 +38,7 @@ JOB_PROVIDER_ENV_KEYS = {
     "codex": frozenset({"CODEX_API_KEY", "OPENAI_API_KEY"}),
     "claude": frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"}),
     "openrouter": frozenset({"OPENROUTER_API_KEY"}),
+    "opencode": frozenset({"OPENCODE_API_KEY"}),
 }
 JOB_HARNESS_ENV_KEYS = {
     "cursor": frozenset({"CURSOR_API_KEY", "CURSOR_AUTH_TOKEN", "CURSOR_AGENT_BIN"}),

--- a/engine/open_kritt_engine/workspace.py
+++ b/engine/open_kritt_engine/workspace.py
@@ -48,6 +48,11 @@ LOGGER = logging.getLogger("open_kritt_engine.workspace")
 SCAN_RUNNER_WORKDIR = "/workspace"
 SELECTED_AGENT_SKILLS_SLUG = "open-kritt-selected-skills"
 OPENROUTER_CODEX_BASE_URL = "https://openrouter.ai/api/v1"
+OPENCODE_CODEX_BASE_URL = "https://opencode.ai/zen/v1"
+GATEWAY_CODEX_PROVIDERS = {
+    "openrouter": {"name": "OpenRouter", "base_url": OPENROUTER_CODEX_BASE_URL, "env_key": "OPENROUTER_API_KEY"},
+    "opencode": {"name": "OpenCode Zen", "base_url": OPENCODE_CODEX_BASE_URL, "env_key": "OPENCODE_API_KEY"},
+}
 JOB_UID_BASE = 100_000
 JOB_UID_SPAN = 2_000_000_000
 _SHARED_WORKSPACE_LOCKS: dict[str, threading.Lock] = {}
@@ -139,7 +144,7 @@ def prepare_job_workspace(
     if needs_codex_home and codex_source:
         _copy_credential_files(Path(codex_source), codex_home, ("auth.json",))
     elif needs_codex_home:
-        _prepare_openrouter_codex_home(codex_home)
+        _prepare_gateway_codex_home(codex_home, selected_provider)
     if needs_claude_home and selected_provider == "claude":
         claude_oauth_expires_at_ms = prepare_claude_job_credentials(
             Path(claude_source or os.getenv("CLAUDE_HOME", "/root/.claude")),
@@ -224,19 +229,20 @@ def _secure_job_tree(root: Path, uid: int, gid: int):
             continue
 
 
-def _prepare_openrouter_codex_home(codex_home: Path):
-    """Create the minimum Codex config needed for an OpenRouter scan."""
+def _prepare_gateway_codex_home(codex_home: Path, provider: str):
+    """Create the minimum Codex config needed for an OpenRouter/OpenCode Zen scan."""
 
+    gateway = GATEWAY_CODEX_PROVIDERS.get(provider, GATEWAY_CODEX_PROVIDERS["openrouter"])
     codex_home.mkdir(parents=True, exist_ok=True)
     config = codex_home / "config.toml"
     _atomic_write_text(
         config,
         "\n".join(
             [
-                "[model_providers.openrouter]",
-                'name = "OpenRouter"',
-                f'base_url = "{OPENROUTER_CODEX_BASE_URL}"',
-                'env_key = "OPENROUTER_API_KEY"',
+                f"[model_providers.{provider}]",
+                f'name = "{gateway["name"]}"',
+                f'base_url = "{gateway["base_url"]}"',
+                f'env_key = "{gateway["env_key"]}"',
                 'wire_api = "responses"',
                 "",
             ]

--- a/engine/tests/test_engine.py
+++ b/engine/tests/test_engine.py
@@ -1300,6 +1300,98 @@ def test_claude_openrouter_stream_rate_limit_is_preserved(monkeypatch, tmp_path)
     assert raised.value.output.stdout == raw_stdout
 
 
+def test_claude_harness_routes_opencode_claude_model_through_anthropic_endpoint(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_process(cmd, prompt, cwd, timeout, env=None):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        payload = marked({"stub": True, "stub_explanation": "No matching records.", "results": []})
+        return SimpleNamespace(
+            stdout="\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+                        }
+                    ),
+                    json.dumps({"type": "result", "result": json.dumps(payload), "usage": {"input_tokens": 1}}),
+                ]
+            ),
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(harnesses, "_run_process", fake_run_process)
+
+    result = ClaudeHarness(timeout_seconds=5, model_provider="opencode").run(
+        prompt="prompt",
+        schema=output_schema('{"thing":"string"}', multi_output=False),
+        repo_dir="/tmp",
+        model="claude-opus-5",
+        env={
+            "HOME": str(tmp_path / "home"),
+            "OPENCODE_API_KEY": "oc-key",
+        },
+    )
+
+    assert result.payload == marked({"stub": True, "stub_explanation": "No matching records.", "results": []})
+    assert captured["cmd"][captured["cmd"].index("--model") + 1] == "claude-opus-5"
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "https://opencode.ai/zen"
+    assert captured["env"]["ANTHROPIC_AUTH_TOKEN"] == "oc-key"
+    assert captured["env"]["ANTHROPIC_API_KEY"] == ""
+    assert captured["cmd"][captured["cmd"].index("--output-format") + 1] == "stream-json"
+    assert "--include-partial-messages" in captured["cmd"]
+    assert "--json-schema" not in captured["cmd"]
+
+
+def test_claude_harness_rejects_gpt_model_on_opencode(tmp_path):
+    with pytest.raises(HarnessError) as raised:
+        ClaudeHarness(timeout_seconds=5, model_provider="opencode").run(
+            prompt="prompt",
+            schema=output_schema('{"thing":"string"}', multi_output=False),
+            repo_dir="/tmp",
+            model="gpt-5.1-codex",
+            env={"HOME": str(tmp_path / "home"), "OPENCODE_API_KEY": "oc-key"},
+        )
+
+    assert raised.value.code == "configuration_error"
+
+
+def test_codex_exec_command_injects_opencode_gateway_provider(tmp_path):
+    cmd = harnesses.codex_exec_command(
+        repo_dir="/tmp",
+        model="gpt-5.1-codex",
+        schema_path=str(tmp_path / "schema.json"),
+        output_path=str(tmp_path / "output.json"),
+        model_provider="opencode",
+        thinking_effort=None,
+        allow_tools=False,
+    )
+
+    assert 'model_providers.opencode.name="OpenCode Zen"' in cmd
+    assert 'model_providers.opencode.base_url="https://opencode.ai/zen/v1"' in cmd
+    assert 'model_providers.opencode.env_key="OPENCODE_API_KEY"' in cmd
+    assert 'model_providers.opencode.wire_api="responses"' in cmd
+    assert 'model_provider="opencode"' in cmd
+
+
+def test_codex_exec_command_rejects_non_gpt_model_on_opencode(tmp_path):
+    with pytest.raises(HarnessError) as raised:
+        harnesses.codex_exec_command(
+            repo_dir="/tmp",
+            model="claude-opus-5",
+            schema_path=str(tmp_path / "schema.json"),
+            output_path=str(tmp_path / "output.json"),
+            model_provider="opencode",
+            thinking_effort=None,
+            allow_tools=False,
+        )
+
+    assert raised.value.code == "configuration_error"
+
+
 def test_native_claude_json_rate_limit_is_preserved(monkeypatch, tmp_path):
     raw_stdout = json.dumps({"is_error": True, "result": "rate limit exceeded", "status": 429})
     monkeypatch.setattr(
@@ -1594,6 +1686,37 @@ def test_openrouter_credit_limits_are_classified_as_rate_limited(monkeypatch, pr
             "/tmp",
             1,
             env={"OPENROUTER_API_KEY": "secret"},
+        )
+
+    assert exc_info.value.code == "rate_limited"
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.parametrize(
+    "provider_output",
+    [
+        '{"error":{"code":"insufficient_quota"}}',
+        '{"error":"requires more credits"}',
+    ],
+)
+def test_opencode_credit_limits_are_classified_as_rate_limited(monkeypatch, provider_output):
+    monkeypatch.setattr(
+        harnesses.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type(
+            "Process",
+            (),
+            {"stdout": provider_output, "stderr": "", "returncode": 1},
+        )(),
+    )
+
+    with pytest.raises(harnesses.HarnessError) as exc_info:
+        harnesses._run_process(
+            ["codex", "exec", "-c", 'model_provider="opencode"'],
+            "prompt",
+            "/tmp",
+            1,
+            env={"OPENCODE_API_KEY": "secret"},
         )
 
     assert exc_info.value.code == "rate_limited"

--- a/engine/tests/test_generation.py
+++ b/engine/tests/test_generation.py
@@ -314,6 +314,17 @@ def test_generation_job_rejects_effort_the_selected_harness_cannot_pass():
     )
 
 
+def test_generation_job_accepts_opencode_provider_with_either_harness():
+    for harness in ("claude-code", "codex"):
+        job = generation_job()
+        job.update({"model": "claude-opus-5", "model_provider": "opencode", "harness": harness})
+
+        validated = validate_generation_job(job)
+
+        assert validated["model_provider"] == "opencode"
+        assert validated["harness"] == harness
+
+
 def test_generation_environment_contains_only_selected_provider_credentials():
     source = {
         "PATH": "/bin",
@@ -322,19 +333,23 @@ def test_generation_environment_contains_only_selected_provider_credentials():
         "OPENAI_API_KEY": "openai-secret",
         "ANTHROPIC_API_KEY": "anthropic-secret",
         "OPENROUTER_API_KEY": "openrouter-secret",
+        "OPENCODE_API_KEY": "opencode-secret",
         "GITHUB_TOKEN": "github-secret",
         "DATABASE_URL": "database-secret",
     }
 
     codex_env = generation_environment("codex", source)
     openrouter_env = generation_environment("openrouter", source)
+    opencode_env = generation_environment("opencode", source)
 
     assert codex_env["CODEX_API_KEY"] == "openai-secret"
     assert codex_env["CODEX_HOME"] == "/codex-a"
     assert "ANTHROPIC_API_KEY" not in codex_env
     assert "OPENROUTER_API_KEY" not in codex_env
     assert openrouter_env["OPENROUTER_API_KEY"] == "openrouter-secret"
-    for env in (codex_env, openrouter_env):
+    assert opencode_env["OPENCODE_API_KEY"] == "opencode-secret"
+    assert "OPENROUTER_API_KEY" not in opencode_env
+    for env in (codex_env, openrouter_env, opencode_env):
         assert "GITHUB_TOKEN" not in env
         assert "DATABASE_URL" not in env
 

--- a/engine/tests/test_model_catalog.py
+++ b/engine/tests/test_model_catalog.py
@@ -14,6 +14,7 @@ from open_kritt_engine.model_catalog import (
     codex_is_configured,
     fetch_anthropic_models,
     fetch_codex_models,
+    fetch_opencode_models,
     fetch_openrouter_models,
     normalize_catalog_models,
 )
@@ -385,6 +386,78 @@ def test_fetch_openrouter_models_rejects_oversized_or_invalid_responses(monkeypa
         fetch_openrouter_models("openrouter-test-key", 2)
 
 
+def _opencode_model(model_id):
+    return {"id": model_id, "object": "model", "created": 1785085813, "owned_by": "opencode"}
+
+
+def test_fetch_opencode_models_filters_to_supported_model_families(monkeypatch):
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        entries = [
+            _opencode_model("claude-opus-5"),
+            _opencode_model("gpt-5.1-codex"),
+            _opencode_model("qwen3.7-max"),
+            _opencode_model("grok-4.5"),
+            _opencode_model("deepseek-v4-pro"),
+            _opencode_model("glm-5.2"),
+        ]
+        return io.BytesIO(json.dumps({"object": "list", "data": entries}).encode("utf-8"))
+
+    monkeypatch.setattr(model_catalog, "urlopen", fake_urlopen)
+    models, default_model = fetch_opencode_models("opencode-test-key", 2)
+
+    assert [model["id"] for model in models] == ["claude-opus-5", "gpt-5.1-codex", "qwen3.7-max"]
+    assert default_model == "gpt-5.1-codex"
+    assert next(model for model in models if model["id"] == "gpt-5.1-codex")["isDefault"] is True
+    assert next(model for model in models if model["id"] == "claude-opus-5")["thinkingEfforts"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert next(model for model in models if model["id"] == "qwen3.7-max")["thinkingEfforts"] == ["default"]
+    request, timeout = requests[0]
+    assert request.full_url == "https://opencode.ai/zen/v1/models"
+    assert request.get_header("Authorization") == "Bearer opencode-test-key"
+    assert timeout == 2
+
+
+def test_fetch_opencode_models_rejects_oversized_or_invalid_responses(monkeypatch):
+    monkeypatch.setattr(model_catalog, "MAX_HTTP_CATALOG_BYTES", 32)
+    monkeypatch.setattr(
+        model_catalog,
+        "urlopen",
+        lambda *_args, **_kwargs: io.BytesIO(b'{"data":[{"id":"gpt-5.1-codex","padding":"too large"}]}'),
+    )
+    with pytest.raises(model_catalog.ModelCatalogError, match="response was too large"):
+        fetch_opencode_models("opencode-test-key", 2)
+
+    monkeypatch.setattr(model_catalog, "MAX_HTTP_CATALOG_BYTES", 1024)
+    monkeypatch.setattr(model_catalog, "urlopen", lambda *_args, **_kwargs: io.BytesIO(b"not-json"))
+    with pytest.raises(model_catalog.ModelCatalogError, match="Could not read the OpenCode Zen model catalog"):
+        fetch_opencode_models("opencode-test-key", 2)
+
+
+def test_refresher_never_persists_opencode_failure_details():
+    db = FakeDatabase()
+    secret = "opencode-secret"
+    refresher = ModelCatalogRefresher(
+        db,
+        env={"OPENCODE_API_KEY": secret},
+        fetch_opencode=lambda: (_ for _ in ()).throw(RuntimeError(f"upstream rejected {secret}")),
+    )
+
+    assert refresher.refresh() == {"opencode": False}
+    assert db.catalogs == []
+    assert db.errors == [
+        {"provider": "opencode", "error": "Unable to refresh the provider model catalog."},
+    ]
+    assert secret not in json.dumps(db.errors)
+
+
 def test_refresher_persists_only_configured_provider_catalogs():
     db = FakeDatabase()
     codex_models = [{"id": "gpt-5-codex", "label": "GPT-5 Codex", "thinkingEfforts": [], "isDefault": True}]
@@ -392,26 +465,32 @@ def test_refresher_persists_only_configured_provider_catalogs():
     openrouter_models = [
         {"id": "vendor/code-model", "label": "Code Model", "thinkingEfforts": ["medium"], "isDefault": True}
     ]
+    opencode_models = [
+        {"id": "gpt-5.1-codex", "label": "gpt-5.1-codex", "thinkingEfforts": ["default"], "isDefault": True}
+    ]
     refresher = ModelCatalogRefresher(
         db,
         env={
             "CODEX_API_KEY": "codex-key",
             "ANTHROPIC_API_KEY": "anthropic-key",
             "OPENROUTER_API_KEY": "openrouter-key",
+            "OPENCODE_API_KEY": "opencode-key",
         },
         fetch_codex=lambda: (codex_models, "gpt-5-codex"),
         fetch_anthropic=lambda: (claude_models, "claude-sonnet-4"),
         fetch_openrouter=lambda: (openrouter_models, "vendor/code-model"),
+        fetch_opencode=lambda: (opencode_models, "gpt-5.1-codex"),
     )
 
-    assert refresher.refresh() == {"codex": True, "claude": True, "openrouter": True}
+    assert refresher.refresh() == {"codex": True, "claude": True, "openrouter": True, "opencode": True}
     assert db.catalogs == [
         {"provider": "codex", "models": codex_models, "default_model": "gpt-5-codex"},
         {"provider": "claude", "models": claude_models, "default_model": "claude-sonnet-4"},
         {"provider": "openrouter", "models": openrouter_models, "default_model": "vendor/code-model"},
+        {"provider": "opencode", "models": opencode_models, "default_model": "gpt-5.1-codex"},
     ]
     assert db.errors == []
-    assert [conn.commits for conn in db.connections] == [1, 1, 1]
+    assert [conn.commits for conn in db.connections] == [1, 1, 1, 1]
 
 
 def test_refresher_preserves_existing_catalog_on_provider_failure():

--- a/engine/tests/test_provider_credentials.py
+++ b/engine/tests/test_provider_credentials.py
@@ -25,6 +25,23 @@ def test_environment_key_bootstraps_managed_store_once(tmp_path):
     assert disabled == set()
 
 
+def test_opencode_environment_key_bootstraps_managed_store_once(tmp_path):
+    credential_path = tmp_path / "providers.json"
+
+    credentials, disabled = bootstrap_managed_provider_credentials(
+        {"OPENCODE_API_KEY": "initial-key"}, str(credential_path)
+    )
+    assert credentials == {"opencode": "initial-key"}
+    assert disabled == set()
+    assert json.loads(credential_path.read_text(encoding="utf-8"))["credentials"] == {"opencode": "initial-key"}
+
+    credentials, disabled = bootstrap_managed_provider_credentials(
+        {"OPENCODE_API_KEY": "changed-env-key"}, str(credential_path)
+    )
+    assert credentials == {"opencode": "initial-key"}
+    assert disabled == set()
+
+
 def test_disabled_environment_key_is_not_bootstrapped_again(tmp_path):
     credential_path = tmp_path / "providers.json"
     credential_path.write_text(
@@ -59,6 +76,7 @@ def test_provider_environment_reads_managed_credentials(tmp_path):
                     "codex": "codex-managed",
                     "claude": "claude-managed",
                     "openrouter": "openrouter-managed",
+                    "opencode": "opencode-managed",
                     "unknown": "ignored",
                 },
             }
@@ -77,6 +95,7 @@ def test_provider_environment_reads_managed_credentials(tmp_path):
     assert env["CODEX_API_KEY"] == "old-codex"
     assert "ANTHROPIC_API_KEY" not in env
     assert env["OPENROUTER_API_KEY"] == "openrouter-managed"
+    assert env["OPENCODE_API_KEY"] == "opencode-managed"
     assert env["UNRELATED"] == "keep"
     assert "unknown" not in env
 
@@ -110,12 +129,15 @@ def test_job_environment_only_includes_selected_provider_and_harness_credentials
         "OPENAI_API_KEY": "openai-secret",
         "ANTHROPIC_API_KEY": "anthropic-secret",
         "OPENROUTER_API_KEY": "openrouter-secret",
+        "OPENCODE_API_KEY": "opencode-secret",
         "CURSOR_API_KEY": "cursor-secret",
     }
 
     codex = job_environment("codex", "codex", source)
     openrouter_claude = job_environment("openrouter", "claude-code", source)
     openrouter_cursor = job_environment("openrouter", "cursor", source)
+    opencode_claude = job_environment("opencode", "claude-code", source)
+    opencode_codex = job_environment("opencode", "codex", source)
 
     assert codex == {"PATH": "/bin", "OPENAI_API_KEY": "openai-secret", "CODEX_API_KEY": "openai-secret"}
     assert openrouter_claude == {"PATH": "/bin", "OPENROUTER_API_KEY": "openrouter-secret"}
@@ -124,6 +146,8 @@ def test_job_environment_only_includes_selected_provider_and_harness_credentials
         "OPENROUTER_API_KEY": "openrouter-secret",
         "CURSOR_API_KEY": "cursor-secret",
     }
-    for env in (codex, openrouter_claude, openrouter_cursor):
+    assert opencode_claude == {"PATH": "/bin", "OPENCODE_API_KEY": "opencode-secret"}
+    assert opencode_codex == {"PATH": "/bin", "OPENCODE_API_KEY": "opencode-secret"}
+    for env in (codex, openrouter_claude, openrouter_cursor, opencode_claude, opencode_codex):
         assert "DATABASE_URL" not in env
         assert "GITHUB_TOKEN" not in env

--- a/engine/tests/test_security_hardening.py
+++ b/engine/tests/test_security_hardening.py
@@ -275,7 +275,8 @@ def test_agent_cli_builds_use_exact_package_versions():
 
 
 @pytest.mark.parametrize("harness_name", ["codex", "claude-code"])
-def test_openrouter_job_home_never_copies_native_provider_secrets(monkeypatch, tmp_path, harness_name):
+@pytest.mark.parametrize("model_provider", ["openrouter", "opencode"])
+def test_gateway_job_home_never_copies_native_provider_secrets(monkeypatch, tmp_path, harness_name, model_provider):
     codex_home = tmp_path / "source-codex"
     claude_home = tmp_path / "source-claude"
     codex_home.mkdir()
@@ -287,12 +288,13 @@ def test_openrouter_job_home_never_copies_native_provider_secrets(monkeypatch, t
     monkeypatch.setenv("ENGINE_CODEX_HOME", str(codex_home))
     monkeypatch.setenv("CLAUDE_HOME", str(claude_home))
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-only")
+    monkeypatch.setenv("OPENCODE_API_KEY", "opencode-only")
 
     workspace = prepare_job_workspace(
         str(tmp_path / "data"),
         200 if harness_name == "codex" else 201,
         harness_name=harness_name,
-        model_provider="openrouter",
+        model_provider=model_provider,
     )
 
     job_home = Path(workspace.env["HOME"])
@@ -303,7 +305,12 @@ def test_openrouter_job_home_never_copies_native_provider_secrets(monkeypatch, t
         assert "mcp-secret" not in config
     assert not (job_home / ".claude" / ".credentials.json").exists()
     assert not (job_home / ".claude" / "settings.json").exists()
-    assert workspace.env["OPENROUTER_API_KEY"] == "openrouter-only"
+    if model_provider == "openrouter":
+        assert workspace.env["OPENROUTER_API_KEY"] == "openrouter-only"
+        assert "OPENCODE_API_KEY" not in workspace.env
+    else:
+        assert workspace.env["OPENCODE_API_KEY"] == "opencode-only"
+        assert "OPENROUTER_API_KEY" not in workspace.env
     assert (Path(workspace.root_dir).stat().st_mode & 0o777) == 0o700
 
 

--- a/executor-view/server.py
+++ b/executor-view/server.py
@@ -305,7 +305,7 @@ def internal_request_path_allowed(method, path):
         method == "GET"
         and len(parts) == 3
         and parts[:2] == ["api", "accounts"]
-        and parts[2] in {"codex", "claude", "openrouter"}
+        and parts[2] in {"codex", "claude", "openrouter", "opencode"}
     ):
         return True
     return (
@@ -727,6 +727,7 @@ def accounts_for_state(force=False):
         empty_codex_accounts(),
         empty_claude_accounts(),
         fetch_openrouter_accounts(force=False),
+        fetch_opencode_accounts(force=False),
         fetched=False,
     )
 
@@ -1187,17 +1188,22 @@ def fetch_accounts(force=False):
         codex = fetch_codex_accounts(force=True)
         claude = fetch_claude_accounts(force=True)
         openrouter = fetch_openrouter_accounts(force=True)
-        data = build_account_overview(codex, claude, openrouter, fetched=True)
+        opencode = fetch_opencode_accounts(force=True)
+        data = build_account_overview(codex, claude, openrouter, opencode, fetched=True)
         ACCOUNT_OVERVIEW_CACHE["data"] = data
         ACCOUNT_OVERVIEW_CACHE["expires_at"] = now + ACCOUNT_OVERVIEW_CACHE_SECONDS
         return data
     codex = fetch_codex_accounts(force=force)
     claude = fetch_claude_accounts(force=force)
     openrouter = fetch_openrouter_accounts(force=force)
-    data = build_account_overview(codex, claude, openrouter, fetched=True)
+    opencode = fetch_opencode_accounts(force=force)
+    data = build_account_overview(codex, claude, openrouter, opencode, fetched=True)
     ACCOUNT_OVERVIEW_CACHE["data"] = data
     ACCOUNT_OVERVIEW_CACHE["expires_at"] = now + ACCOUNT_OVERVIEW_CACHE_SECONDS
     return data
+
+
+ACCOUNT_ONLY_STALE_PROVIDERS = {"codex", "claude"}
 
 
 def fetch_account_provider(kind, force=False):
@@ -1205,6 +1211,7 @@ def fetch_account_provider(kind, force=False):
         "codex": fetch_codex_accounts,
         "claude": fetch_claude_accounts,
         "openrouter": fetch_openrouter_accounts,
+        "opencode": fetch_opencode_accounts,
     }
     fetcher = fetchers.get(kind)
     if not fetcher:
@@ -1226,6 +1233,10 @@ def build_account_provider(kind, data):
             "OpenRouter",
             "Verified OpenRouter key status, credit usage, limits, and masked metadata.",
         ),
+        "opencode": (
+            "OpenCode Zen",
+            "OpenCode Zen API key configuration status.",
+        ),
     }
     label, description = metadata[kind]
     return {
@@ -1235,17 +1246,18 @@ def build_account_provider(kind, data):
         "active": data.get("active", 0),
         "total": data.get("total", 0),
         "limited": data.get("limited", 0),
-        "stale": data.get("stale", 0) if kind != "openrouter" else 0,
+        "stale": data.get("stale", 0) if kind in ACCOUNT_ONLY_STALE_PROVIDERS else 0,
         "accounts": data.get("accounts", []),
         "configuredRaw": data.get("configuredRaw"),
     }
 
 
-def build_account_overview(codex, claude, openrouter, fetched=True):
+def build_account_overview(codex, claude, openrouter, opencode, fetched=True):
     providers = [
         build_account_provider("codex", codex),
         build_account_provider("claude", claude),
         build_account_provider("openrouter", openrouter),
+        build_account_provider("opencode", opencode),
     ]
     return {
         "generatedAt": datetime.now(timezone.utc),
@@ -1265,6 +1277,7 @@ def build_account_overview(codex, claude, openrouter, fetched=True):
         "codex": codex,
         "claude": claude,
         "openrouter": openrouter,
+        "opencode": opencode,
         "providers": providers,
     }
 
@@ -1810,6 +1823,64 @@ def openrouter_base_details(model_provider):
     return details
 
 
+def empty_opencode_accounts():
+    return {
+        "generatedAt": datetime.now(timezone.utc),
+        "configuredRaw": "OPENCODE_API_KEY",
+        "active": 0,
+        "total": 0,
+        "limited": 0,
+        "accounts": [],
+    }
+
+
+def fetch_opencode_accounts(force=False):  # noqa: ARG001 - matches the other fetchers' shared call signature
+    # Unlike OpenRouter, OpenCode Zen does not publish a documented key-info
+    # endpoint, so this reports configuration status only, not live usage.
+    api_key = configured_secret("OPENCODE_API_KEY") or configured_secret(
+        "EXECUTOR_VIEW_OPENCODE_API_KEY"
+    )
+    if not api_key:
+        account = {
+            "provider": "OpenCode Zen",
+            "label": "OpenCode Zen API key",
+            "path": "OPENCODE_API_KEY",
+            "active": False,
+            "status": "missing key",
+            "statusKind": "missing",
+            "details": [],
+        }
+        return {
+            "generatedAt": datetime.now(timezone.utc),
+            "configuredRaw": "OPENCODE_API_KEY",
+            "active": 0,
+            "total": 0,
+            "limited": 0,
+            "accounts": [account],
+        }
+
+    details = []
+    add_detail(details, "OPENCODE_API_KEY", masked_secret(api_key), mono=True)
+    add_detail(details, "Key fingerprint", secret_fingerprint(api_key), mono=True)
+    account = {
+        "provider": "OpenCode Zen",
+        "label": "OpenCode Zen API key",
+        "path": "OPENCODE_API_KEY",
+        "active": True,
+        "status": "key configured",
+        "statusKind": "available",
+        "details": details,
+    }
+    return {
+        "generatedAt": datetime.now(timezone.utc),
+        "configuredRaw": "OPENCODE_API_KEY",
+        "active": 1,
+        "total": 1,
+        "limited": 0,
+        "accounts": [account],
+    }
+
+
 def openrouter_key_info_for_account(api_key, force=False):
     now = time.monotonic()
     credential = secret_fingerprint(api_key)
@@ -1881,13 +1952,20 @@ def fetch_openrouter_key_info(api_key):
         }
 
 
+MANAGED_ACCOUNT_PROVIDER_ENV_KEYS = {
+    "OPENROUTER_API_KEY": "openrouter",
+    "OPENCODE_API_KEY": "opencode",
+}
+
+
 def configured_secret(name):
-    if name == "OPENROUTER_API_KEY":
+    if name in MANAGED_ACCOUNT_PROVIDER_ENV_KEYS:
+        provider = MANAGED_ACCOUNT_PROVIDER_ENV_KEYS[name]
         state = managed_provider_credential_state()
-        managed = state["credentials"].get("openrouter")
+        managed = state["credentials"].get(provider)
         if managed:
             return managed
-        if "openrouter" in state["disabledEnvironmentProviders"]:
+        if provider in state["disabledEnvironmentProviders"]:
             return None
     value = os.getenv(name)
     value = value.strip() if isinstance(value, str) else ""
@@ -1905,19 +1983,21 @@ def managed_provider_credential_state():
     if not isinstance(payload, dict):
         return empty
 
+    known_providers = set(MANAGED_ACCOUNT_PROVIDER_ENV_KEYS.values())
     credentials = {}
     raw_credentials = payload.get("credentials")
     if isinstance(raw_credentials, dict):
-        value = raw_credentials.get("openrouter")
-        if isinstance(value, str) and value.strip():
-            credentials["openrouter"] = value.strip()
+        for provider in known_providers:
+            value = raw_credentials.get(provider)
+            if isinstance(value, str) and value.strip():
+                credentials[provider] = value.strip()
 
     raw_disabled = payload.get("disabledEnvironmentProviders")
     disabled = (
         {
             provider
             for provider in raw_disabled
-            if isinstance(provider, str) and provider == "openrouter"
+            if isinstance(provider, str) and provider in known_providers
         }
         if isinstance(raw_disabled, list)
         else set()
@@ -4197,7 +4277,7 @@ class Handler(BaseHTTPRequestHandler):
         if (
             len(parts) == 3
             and parts[:2] == ["api", "accounts"]
-            and parts[2] in {"codex", "claude", "openrouter"}
+            and parts[2] in {"codex", "claude", "openrouter", "opencode"}
         ):
             try:
                 query = parse_qs(parsed.query)

--- a/executor-view/test_server.py
+++ b/executor-view/test_server.py
@@ -230,6 +230,12 @@ class ExecutorViewSummaryTests(unittest.TestCase):
         self.assertTrue(
             server.internal_request_path_allowed("GET", "/api/accounts/claude")
         )
+        self.assertTrue(
+            server.internal_request_path_allowed("GET", "/api/accounts/openrouter")
+        )
+        self.assertTrue(
+            server.internal_request_path_allowed("GET", "/api/accounts/opencode")
+        )
         self.assertFalse(
             server.internal_request_path_allowed("GET", "/api/accounts/unknown")
         )
@@ -429,6 +435,13 @@ class ExecutorViewSummaryTests(unittest.TestCase):
             "accounts": [],
             "configuredRaw": None,
         }
+        opencode = {
+            "active": 0,
+            "total": 0,
+            "limited": 0,
+            "accounts": [],
+            "configuredRaw": None,
+        }
         server.ACCOUNT_OVERVIEW_CACHE = {"expires_at": 0.0, "data": None}
 
         with (
@@ -440,11 +453,15 @@ class ExecutorViewSummaryTests(unittest.TestCase):
             patch.object(
                 server, "fetch_openrouter_accounts", return_value=openrouter
             ) as fetch_openrouter,
+            patch.object(
+                server, "fetch_opencode_accounts", return_value=opencode
+            ) as fetch_opencode,
         ):
             overview = server.fetch_accounts(force=True)
 
         fetch_codex.assert_called_once_with(force=True)
         fetch_openrouter.assert_called_once_with(force=True)
+        fetch_opencode.assert_called_once_with(force=True)
         self.assertEqual(overview["codex"]["total"], 1)
         self.assertEqual(overview["active"], 1)
 
@@ -1177,6 +1194,67 @@ class ExecutorViewSummaryTests(unittest.TestCase):
                 patch.dict(server.os.environ, {"OPENROUTER_API_KEY": "initial-key"}),
             ):
                 self.assertIsNone(server.configured_secret("OPENROUTER_API_KEY"))
+
+    def test_opencode_account_reports_configuration_status_without_a_remote_check(self):
+        with patch.object(
+            server,
+            "configured_secret",
+            side_effect=lambda name: (
+                "unit-test-api-key" if name == "OPENCODE_API_KEY" else None
+            ),
+        ):
+            result = server.fetch_opencode_accounts(force=True)
+
+        account = result["accounts"][0]
+        self.assertEqual(account["status"], "key configured")
+        self.assertEqual(account["statusKind"], "available")
+        serialized = json.dumps(result, default=server.encode)
+        self.assertNotIn("unit-test-api-key", serialized)
+
+    def test_opencode_account_reports_missing_key(self):
+        with patch.object(server, "configured_secret", return_value=None):
+            result = server.fetch_opencode_accounts(force=True)
+
+        account = result["accounts"][0]
+        self.assertEqual(account["status"], "missing key")
+        self.assertEqual(account["statusKind"], "missing")
+        self.assertEqual(result["active"], 0)
+
+    def test_managed_opencode_key_overrides_environment_and_disable_is_sticky(self):
+        with tempfile.TemporaryDirectory() as directory:
+            credential_path = Path(directory) / "providers.json"
+            credential_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "credentials": {"opencode": "managed-key"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(server, "PROVIDER_CREDENTIALS_PATH", credential_path),
+                patch.dict(server.os.environ, {"OPENCODE_API_KEY": "initial-key"}),
+            ):
+                self.assertEqual(
+                    server.configured_secret("OPENCODE_API_KEY"), "managed-key"
+                )
+
+            credential_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "credentials": {},
+                        "disabledEnvironmentProviders": ["opencode"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(server, "PROVIDER_CREDENTIALS_PATH", credential_path),
+                patch.dict(server.os.environ, {"OPENCODE_API_KEY": "initial-key"}),
+            ):
+                self.assertIsNone(server.configured_secret("OPENCODE_API_KEY"))
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/ModelConfiguration.jsx
+++ b/frontend/src/components/ModelConfiguration.jsx
@@ -21,6 +21,7 @@ const PROVIDER_LABELS = {
   codex: 'Codex',
   claude: 'Claude',
   openrouter: 'OpenRouter',
+  opencode: 'OpenCode Zen',
 };
 
 export function modelConfigurationForCatalog(current, providers, catalog) {

--- a/frontend/src/lib/generationFailure.js
+++ b/frontend/src/lib/generationFailure.js
@@ -4,6 +4,7 @@ const PROVIDER_LABELS = {
   codex: 'Codex',
   claude: 'Claude',
   openrouter: 'OpenRouter',
+  opencode: 'OpenCode Zen',
 };
 
 const HARNESS_LABELS = {

--- a/frontend/src/lib/modelProviders.js
+++ b/frontend/src/lib/modelProviders.js
@@ -1,4 +1,4 @@
-export const MODEL_PROVIDER_IDS = ['codex', 'claude', 'openrouter'];
+export const MODEL_PROVIDER_IDS = ['codex', 'claude', 'openrouter', 'opencode'];
 export const MODEL_CATALOG_STATUSES = ['ready', 'loading', 'unavailable'];
 const SAFE_MODEL_NOTE_URLS = new Set(['https://chatgpt.com/cyber']);
 
@@ -8,18 +8,23 @@ const PROVIDER_HARNESSES = {
   // Claude Code has first-class OpenRouter support. Codex remains available
   // for advanced installations with a matching Codex provider configuration.
   openrouter: ['claude-code', 'codex'],
+  // OpenCode Zen is not a unified gateway like OpenRouter: Claude Code only
+  // reaches its claude-*/qwen* models, Codex only reaches its gpt-* models.
+  opencode: ['claude-code', 'codex'],
 };
 
 const PROVIDER_DEFAULT_MODELS = {
   codex: 'gpt-5-codex',
   claude: 'claude-sonnet-5',
   openrouter: 'z-ai/glm-5.2',
+  opencode: 'gpt-5.1-codex',
 };
 
 const PROVIDER_THINKING_EFFORTS = {
   codex: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
   claude: ['low', 'medium', 'high', 'xhigh', 'max'],
   openrouter: ['default', 'low', 'medium', 'high', 'xhigh', 'max'],
+  opencode: ['default', 'low', 'medium', 'high', 'xhigh', 'max'],
 };
 
 const HARNESS_THINKING_EFFORTS = {
@@ -106,10 +111,15 @@ export function modelsForModelProvider(catalog, provider) {
   return modelCatalogForProvider(catalog, provider)?.models || [];
 }
 
+const FREE_TEXT_MODEL_INPUT_PROVIDERS = ['openrouter', 'opencode'];
+
 export function usesFreeTextModelInput(catalog, provider) {
   const normalizedProvider = normalizedProviderId(provider);
   const providerCatalog = modelCatalogForProvider(catalog, normalizedProvider);
-  return providerCatalog?.input === 'text' || (!providerCatalog && normalizedProvider === 'openrouter');
+  return (
+    providerCatalog?.input === 'text' ||
+    (!providerCatalog && FREE_TEXT_MODEL_INPUT_PROVIDERS.includes(normalizedProvider))
+  );
 }
 
 export function modelCatalogIsReady(catalog, provider) {

--- a/frontend/src/lib/modelProviders.test.js
+++ b/frontend/src/lib/modelProviders.test.js
@@ -61,11 +61,9 @@ const modelCatalog = configuredModelCatalog({
 
 describe('configuredModelProviders', () => {
   it('uses only supported provider IDs returned by the API', () => {
-    expect(configuredModelProviders({ providers: ['OPENROUTER', 'unknown', 'claude', 'codex', 'codex'] })).toEqual([
-      'codex',
-      'claude',
-      'openrouter',
-    ]);
+    expect(
+      configuredModelProviders({ providers: ['OPENROUTER', 'unknown', 'claude', 'codex', 'codex', 'opencode'] })
+    ).toEqual(['codex', 'claude', 'openrouter', 'opencode']);
   });
 
   it('handles empty and malformed availability responses', () => {
@@ -79,6 +77,7 @@ describe('model provider defaults', () => {
     expect(defaultModelForModelProvider('codex')).toBe('gpt-5-codex');
     expect(defaultModelForModelProvider('claude')).toBe('claude-sonnet-5');
     expect(defaultModelForModelProvider('openrouter')).toBe('z-ai/glm-5.2');
+    expect(defaultModelForModelProvider('opencode')).toBe('gpt-5.1-codex');
   });
 
   it('moves provider-owned model defaults with the provider', () => {
@@ -185,6 +184,18 @@ describe('model catalog', () => {
     expect(modelForCatalogChange('gpt-5-codex', 'codex', 'openrouter', loadingCatalog)).toBe('');
   });
 
+  it('keeps exact OpenCode Zen IDs usable while suggestions load or refresh', () => {
+    const loadingCatalog = configuredModelCatalog({
+      providers: [{ provider: 'opencode', input: 'text', status: 'loading', models: [] }],
+    });
+
+    expect(usesFreeTextModelInput(loadingCatalog, 'opencode')).toBe(true);
+    expect(modelCatalogIsReady(loadingCatalog, 'opencode')).toBe(false);
+    expect(isModelSelectionValid('gpt-5.1-codex', loadingCatalog, 'opencode')).toBe(true);
+    expect(modelForCatalogChange('gpt-5.1-codex', 'opencode', 'opencode', loadingCatalog)).toBe('gpt-5.1-codex');
+    expect(modelForCatalogChange('gpt-5-codex', 'codex', 'opencode', loadingCatalog)).toBe('');
+  });
+
   it('uses only the selected native model thinking efforts', () => {
     expect(thinkingEffortsForModel(modelCatalog, 'codex', 'gpt-5-codex', ['low', 'medium', 'high', 'xhigh'])).toEqual([
       'low',
@@ -242,6 +253,11 @@ describe('model provider harnesses', () => {
   it('defaults OpenRouter to Claude Code and retains Codex as an advanced option', () => {
     expect(harnessesForModelProvider('openrouter')).toEqual(['claude-code', 'codex']);
     expect(defaultHarnessForModelProvider('openrouter')).toBe('claude-code');
+  });
+
+  it('offers both harnesses for OpenCode Zen, since its model families are endpoint-specific', () => {
+    expect(harnessesForModelProvider('opencode')).toEqual(['claude-code', 'codex']);
+    expect(defaultHarnessForModelProvider('opencode')).toBe('claude-code');
   });
 
   it('returns no harness for an unsupported provider', () => {

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -8,6 +8,7 @@ import { usePagination } from '../lib/usePagination.js';
 
 const PROVIDER_LINKS = {
   openrouter: 'https://openrouter.ai/settings/keys',
+  opencode: 'https://opencode.ai/auth',
 };
 
 const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
@@ -101,7 +102,7 @@ export default function Accounts() {
   };
 
   const remove = async (provider) => {
-    if (!window.confirm('Remove the OpenRouter API key from open·kritt?')) return;
+    if (!window.confirm(`Remove the ${provider.label} API key from open·kritt?`)) return;
     const previous = data;
     setData(removeProviderFromOverview(data, provider.id));
     try {
@@ -169,7 +170,7 @@ export default function Accounts() {
           <div style={{ fontSize: 27, fontWeight: 600, letterSpacing: '-0.02em' }}>Accounts</div>
           <div style={{ color: 'var(--text-2)', marginTop: 7, maxWidth: 680, lineHeight: 1.5 }}>
             See which model providers are ready. Sign in to Codex or Claude with their official login flows, or add an
-            OpenRouter API key. Secret values are never returned by the API.
+            OpenRouter or OpenCode Zen API key. Secret values are never returned by the API.
           </div>
         </div>
         {data && (
@@ -351,7 +352,7 @@ function ProviderCard({
 }
 
 export function providerActionLabel(provider) {
-  if (provider.management !== 'login') return provider.configured ? 'Add or replace key' : 'Add OpenRouter key';
+  if (provider.management !== 'login') return provider.configured ? 'Add or replace key' : `Add ${provider.label} key`;
   const signInRequired = provider.accounts.some((account) => account.statusKind === 'expired');
   if (provider.id === 'codex') return signInRequired ? 'Sign in to Codex again' : 'Add Codex account';
   if (signInRequired) return 'Sign in to Claude again';

--- a/frontend/src/pages/Accounts.test.js
+++ b/frontend/src/pages/Accounts.test.js
@@ -18,6 +18,20 @@ import {
   startCodexWeeklyUsageUntilStarted,
 } from './Accounts.jsx';
 
+describe('API-key managed providers', () => {
+  it('names the specific provider when offering to add its key', () => {
+    expect(
+      providerActionLabel({ id: 'openrouter', label: 'OpenRouter', management: 'api_key', configured: false })
+    ).toBe('Add OpenRouter key');
+    expect(
+      providerActionLabel({ id: 'opencode', label: 'OpenCode Zen', management: 'api_key', configured: false })
+    ).toBe('Add OpenCode Zen key');
+    expect(
+      providerActionLabel({ id: 'opencode', label: 'OpenCode Zen', management: 'api_key', configured: true })
+    ).toBe('Add or replace key');
+  });
+});
+
 describe('expired Codex login', () => {
   it('explains that authentication, not usage, needs attention', () => {
     const html = renderToStaticMarkup(createElement(CodexSignInRequired));

--- a/scripts/kritt-lib.mjs
+++ b/scripts/kritt-lib.mjs
@@ -6,10 +6,21 @@ import { homedir, tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 
-export const PROVIDER_KEYS = ['CODEX_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY'];
+export const PROVIDER_KEYS = [
+  'CODEX_API_KEY',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'OPENCODE_API_KEY',
+];
 export const CODEX_LOGIN_STATUS_KEY = 'CODEX_LOGIN_CONFIGURED';
-const MANAGED_PROVIDER_LABELS = {
+export const MANAGED_PROVIDER_LABELS = {
   openrouter: 'OpenRouter API key',
+  opencode: 'OpenCode Zen API key',
+};
+export const MANAGED_PROVIDER_ENV_KEYS = {
+  OPENROUTER_API_KEY: 'openrouter',
+  OPENCODE_API_KEY: 'opencode',
 };
 const CODEX_LOGIN_CONTAINER_USER_HOME = '/open-kritt-login';
 const CODEX_LOGIN_CONTAINER_HOME = `${CODEX_LOGIN_CONTAINER_USER_HOME}/.codex`;
@@ -36,6 +47,11 @@ export const ENVIRONMENT_ITEMS = [
     key: 'OPENROUTER_API_KEY',
     label: 'OpenRouter API key',
     info: 'Used for supported OpenRouter-compatible model and harness selections.',
+  },
+  {
+    key: 'OPENCODE_API_KEY',
+    label: 'OpenCode Zen API key',
+    info: 'Used for OpenCode Zen-hosted Claude and GPT-5.x-codex model and harness selections.',
   },
   {
     key: 'GITHUB_TOKEN',
@@ -473,7 +489,8 @@ export async function getSetupStatus({ rootDir, envFile = join(rootDir, '.env'),
   const valuesPresent = Object.fromEntries(
     ENVIRONMENT_ITEMS.map(({ key }) => [
       key,
-      Boolean(values[key]) && !(key === 'OPENROUTER_API_KEY' && disabledProviders.includes('openrouter')),
+      Boolean(values[key]) &&
+        !(key in MANAGED_PROVIDER_ENV_KEYS && disabledProviders.includes(MANAGED_PROVIDER_ENV_KEYS[key])),
     ])
   );
   const codexAuthInspections = await Promise.all(
@@ -715,17 +732,17 @@ async function manageEnvironmentItem(context, item) {
       write(io, 'Nothing changed.');
       return;
     }
-    if (item.key === 'OPENROUTER_API_KEY') {
+    if (item.key in MANAGED_PROVIDER_ENV_KEYS) {
       const status = await getSetupStatus(context);
-      await saveManagedProviderCredential(status.credentialsPath, 'openrouter', value);
+      await saveManagedProviderCredential(status.credentialsPath, MANAGED_PROVIDER_ENV_KEYS[item.key], value);
     }
     await setEnvValue(envFile, item.key, value);
     write(io, `${item.label} saved.`);
   } else if (action === '2') {
     if (await prompter.confirm(`Unset ${item.label}?`)) {
-      if (item.key === 'OPENROUTER_API_KEY') {
+      if (item.key in MANAGED_PROVIDER_ENV_KEYS) {
         const status = await getSetupStatus(context);
-        await disableManagedProviderCredential(status.credentialsPath, 'openrouter');
+        await disableManagedProviderCredential(status.credentialsPath, MANAGED_PROVIDER_ENV_KEYS[item.key]);
       }
       await setEnvValue(envFile, item.key, '');
       write(io, `${item.label} unset.`);
@@ -1033,8 +1050,7 @@ async function manageCodexLogin(context) {
       if (result.ok) {
         await syncCodexLoginStatus(context);
         write(io, result.message);
-      }
-      else writeError(io, result.message);
+      } else writeError(io, result.message);
     }
   } else if (action === '4') {
     write(io, itemInfo(CODEX_LOGIN));
@@ -1100,11 +1116,12 @@ export async function runSetup(options = {}) {
     write(context.io, '4) OpenAI API key');
     write(context.io, '5) Anthropic API key');
     write(context.io, '6) OpenRouter API key');
-    write(context.io, '7) GitHub token');
-    write(context.io, '8) Finish setup');
+    write(context.io, '7) OpenCode Zen API key');
+    write(context.io, '8) GitHub token');
+    write(context.io, '9) Finish setup');
     const choice = (await context.prompter.ask('Choose an item: ')).toLowerCase();
 
-    if (choice === '8' || choice === 'q' || choice === 'quit') break;
+    if (choice === '9' || choice === 'q' || choice === 'quit') break;
     if (choice === '1') {
       await manageCodexLogin(context);
       continue;
@@ -1113,7 +1130,7 @@ export async function runSetup(options = {}) {
       await manageClaudeLogin(context);
       continue;
     }
-    const item = ENVIRONMENT_ITEMS[Number(choice) - 3] || (choice === '7' ? ENVIRONMENT_ITEMS[4] : null);
+    const item = ENVIRONMENT_ITEMS[Number(choice) - 3];
     if (!item) {
       write(context.io, 'Choose a listed item.');
       continue;
@@ -1182,7 +1199,7 @@ Creates .env from .env.example when it does not exist, shows credential status, 
 
 Configure one model provider key or a saved Codex or Claude login. GITHUB_TOKEN is optional and only needed for private GitHub repositories.
 
-The Codex and Claude login flows use temporary engine containers and persist their provider credentials in the same homes monitored by Accounts. OpenRouter keys are saved in .env and mirrored to the managed credential store used by running services.
+The Codex and Claude login flows use temporary engine containers and persist their provider credentials in the same homes monitored by Accounts. OpenRouter and OpenCode Zen keys are saved in .env and mirrored to the managed credential store used by running services.
 
 The recommended Codex flow uses device authentication (no localhost callback) and saves auth.json with host-user ownership and private permissions.
 

--- a/scripts/kritt-ui.mjs
+++ b/scripts/kritt-ui.mjs
@@ -6,6 +6,8 @@ import {
   CLAUDE_LOGIN,
   CODEX_LOGIN,
   ENVIRONMENT_ITEMS,
+  MANAGED_PROVIDER_ENV_KEYS,
+  MANAGED_PROVIDER_LABELS,
   disableManagedProviderCredential,
   UserCancelledError,
   ensureEnvFile,
@@ -354,6 +356,13 @@ function hiddenIo() {
   };
 }
 
+function isEnvironmentItemPresent(item, status) {
+  return (
+    status.valuesPresent[item.key] ||
+    (item.key in MANAGED_PROVIDER_ENV_KEYS && status.managedProviders.includes(MANAGED_PROVIDER_ENV_KEYS[item.key]))
+  );
+}
+
 function statusDetails(status) {
   const modelAccessDetail = (text, present) => ({ text, tone: present ? 'success' : 'warning' });
   const codexLoginText = status.codexLoginPresent
@@ -371,16 +380,14 @@ function statusDetails(status) {
     ),
   ];
   details.push(
-    ...ENVIRONMENT_ITEMS.slice(0, 4).map((item) => {
-      const present =
-        status.valuesPresent[item.key] ||
-        (item.key === 'OPENROUTER_API_KEY' && status.managedProviders.includes('openrouter'));
+    ...ENVIRONMENT_ITEMS.slice(0, 5).map((item) => {
+      const present = isEnvironmentItemPresent(item, status);
       return modelAccessDetail(`${present ? '✓' : '○'} ${item.label} ${present ? 'present' : 'not set'}`, present);
     })
   );
   details.push(
     ...(status.managedProviders || []).map((provider) => ({
-      text: `✓ ${provider === 'codex' ? 'Codex' : provider === 'claude' ? 'Anthropic' : 'OpenRouter'} API key present (managed from Accounts)`,
+      text: `✓ ${MANAGED_PROVIDER_LABELS[provider] || 'OpenRouter API key'} present (managed from Accounts)`,
       tone: 'success',
     }))
   );
@@ -402,9 +409,7 @@ async function showInfo(terminal, { title, message }) {
 async function manageEnvironmentItem(terminal, context, item) {
   while (true) {
     const status = await getSetupStatus(context);
-    const present =
-      status.valuesPresent[item.key] ||
-      (item.key === 'OPENROUTER_API_KEY' && status.managedProviders.includes('openrouter'));
+    const present = isEnvironmentItemPresent(item, status);
     const choice = await terminal.choose({
       title: item.label,
       subtitle: present ? 'Credential is configured' : 'Credential is not configured',
@@ -427,7 +432,7 @@ async function manageEnvironmentItem(terminal, context, item) {
         title: item.label,
         subtitle: 'Set credential',
         description:
-          item.key === 'OPENROUTER_API_KEY'
+          item.key in MANAGED_PROVIDER_ENV_KEYS
             ? `Paste the ${item.label}. It will be stored in .env and mirrored to the managed credential store used by running services.`
             : `Paste the ${item.label}. It will be stored in .env and is never shown in this interface.`,
         secret: true,
@@ -441,8 +446,8 @@ async function manageEnvironmentItem(terminal, context, item) {
         });
         continue;
       }
-      if (item.key === 'OPENROUTER_API_KEY') {
-        await saveManagedProviderCredential(status.credentialsPath, 'openrouter', value);
+      if (item.key in MANAGED_PROVIDER_ENV_KEYS) {
+        await saveManagedProviderCredential(status.credentialsPath, MANAGED_PROVIDER_ENV_KEYS[item.key], value);
       }
       await setEnvValue(context.envFile, item.key, value);
       await terminal.notice({
@@ -457,21 +462,21 @@ async function manageEnvironmentItem(terminal, context, item) {
         title: item.label,
         subtitle: 'Unset credential',
         message:
-          item.key === 'OPENROUTER_API_KEY'
+          item.key in MANAGED_PROVIDER_ENV_KEYS
             ? `Unset ${item.label}? This removes the managed key and prevents the initial .env value from being imported again.`
             : `Unset ${item.label}? This removes the configured value from .env.`,
         confirmLabel: 'Unset credential',
       })
     ) {
-      if (item.key === 'OPENROUTER_API_KEY') {
-        await disableManagedProviderCredential(status.credentialsPath, 'openrouter');
+      if (item.key in MANAGED_PROVIDER_ENV_KEYS) {
+        await disableManagedProviderCredential(status.credentialsPath, MANAGED_PROVIDER_ENV_KEYS[item.key]);
       }
       await setEnvValue(context.envFile, item.key, '');
       await terminal.notice({
         title: item.label,
         subtitle: 'Unset',
         message:
-          item.key === 'OPENROUTER_API_KEY'
+          item.key in MANAGED_PROVIDER_ENV_KEYS
             ? 'The credential was removed from .env and the managed store.'
             : 'The credential was removed from .env.',
       });
@@ -677,14 +682,10 @@ async function runSetupScreen(terminal, context) {
           label: 'Claude login',
           description: status.claudeLoginPresent ? 'present' : 'sign in with a Claude subscription',
         },
-        ...ENVIRONMENT_ITEMS.slice(0, 4).map((item) => ({
+        ...ENVIRONMENT_ITEMS.slice(0, 5).map((item) => ({
           id: item.key,
           label: item.label,
-          description:
-            status.valuesPresent[item.key] ||
-            (item.key === 'OPENROUTER_API_KEY' && status.managedProviders.includes('openrouter'))
-              ? 'present'
-              : 'not set',
+          description: isEnvironmentItemPresent(item, status) ? 'present' : 'not set',
         })),
         {
           id: 'GITHUB_TOKEN',

--- a/scripts/kritt-ui.test.mjs
+++ b/scripts/kritt-ui.test.mjs
@@ -181,6 +181,24 @@ test('interactive setup saves OpenRouter in .env and the shared managed store', 
   assert.equal(store.credentials.openrouter, 'openrouter-hidden');
 });
 
+test('interactive setup saves OpenCode Zen in .env and the shared managed store', async (t) => {
+  const project = await createProject(t);
+  const terminal = new ScriptedTerminal({
+    choices: ['setup', 'OPENCODE_API_KEY', 'set', 'back', 'back', 'back'],
+    inputs: ['opencode-hidden'],
+  });
+
+  const result = await runInteractiveCli({ ...project, terminal });
+  const env = parseEnv(await readFile(project.envFile, 'utf8'));
+  const store = JSON.parse(
+    await readFile(join(project.rootDir, '.data', 'engine', 'credentials', 'providers.json'), 'utf8')
+  );
+
+  assert.deepEqual(result, { code: 0 });
+  assert.equal(env.OPENCODE_API_KEY, 'opencode-hidden');
+  assert.equal(store.credentials.opencode, 'opencode-hidden');
+});
+
 test('interactive Codex import shows a specific credential error', async (t) => {
   const project = await createProject(t);
   const terminal = new ScriptedTerminal({

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -223,7 +223,7 @@ test('setup stores a selected secret without printing it', async (t) => {
   await runSetup({
     ...project,
     io,
-    prompter: answers({ ask: ['3', '1', '8'], secret: [secret] }),
+    prompter: answers({ ask: ['3', '1', '9'], secret: [secret] }),
   });
 
   assert.equal(parseEnv(await readFile(project.envFile, 'utf8')).CODEX_API_KEY, secret);
@@ -238,7 +238,7 @@ test('setup stores OpenRouter in .env and the managed credential store', async (
   await runSetup({
     ...project,
     io,
-    prompter: answers({ ask: ['6', '1', '8'], secret: [secret] }),
+    prompter: answers({ ask: ['6', '1', '9'], secret: [secret] }),
   });
 
   const env = parseEnv(await readFile(project.envFile, 'utf8'));
@@ -247,6 +247,27 @@ test('setup stores OpenRouter in .env and the managed credential store', async (
   );
   assert.equal(env.OPENROUTER_API_KEY, secret);
   assert.equal(store.credentials.openrouter, secret);
+  assert.deepEqual(store.disabledEnvironmentProviders, []);
+  assert.doesNotMatch(io.output.text, new RegExp(secret));
+});
+
+test('setup stores OpenCode Zen in .env and the managed credential store', async (t) => {
+  const project = await createProject(t);
+  const io = testIo();
+  const secret = 'opencode-managed-secret';
+
+  await runSetup({
+    ...project,
+    io,
+    prompter: answers({ ask: ['7', '1', '9'], secret: [secret] }),
+  });
+
+  const env = parseEnv(await readFile(project.envFile, 'utf8'));
+  const store = JSON.parse(
+    await readFile(join(project.rootDir, '.data', 'engine', 'credentials', 'providers.json'), 'utf8')
+  );
+  assert.equal(env.OPENCODE_API_KEY, secret);
+  assert.equal(store.credentials.opencode, secret);
   assert.deepEqual(store.disabledEnvironmentProviders, []);
   assert.doesNotMatch(io.output.text, new RegExp(secret));
 });
@@ -287,7 +308,7 @@ test('guided Claude login uses the shared home monitored by Accounts', async (t)
   await runSetup({
     ...project,
     io,
-    prompter: answers({ ask: ['2', '1', '8'] }),
+    prompter: answers({ ask: ['2', '1', '9'] }),
     runner,
   });
 
@@ -320,7 +341,7 @@ test('setup explains the optional GitHub token', async (t) => {
   await runSetup({
     ...project,
     io,
-    prompter: answers({ ask: ['7', '3', '8'] }),
+    prompter: answers({ ask: ['8', '3', '9'] }),
   });
 
   assert.match(io.output.text, /private GitHub repositories/);
@@ -397,7 +418,7 @@ test('guided Docker login copies a host-owned auth file from an isolated contain
   await runSetup({
     ...project,
     io,
-    prompter: answers({ ask: ['1', '1', '8'] }),
+    prompter: answers({ ask: ['1', '1', '9'] }),
     runner,
   });
 
@@ -446,10 +467,7 @@ test('guided Docker login copies a host-owned auth file from an isolated contain
   ]);
   assert.match(commands[1].args.at(-1), /open-kritt-codex-login-.*auth\.json$/);
   assert.equal(await readFile(targetPath, 'utf8'), '{"tokens":{"access_token":"test"}}');
-  assert.equal(
-    (await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777,
-    0o700
-  );
+  assert.equal((await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777, 0o700);
   assert.equal((await stat(targetPath)).mode & 0o777, 0o600);
   assert.equal((await getSetupStatus(project)).codexLoginPresent, true);
   assert.equal(parseEnv(await readFile(project.envFile, 'utf8')).CODEX_LOGIN_CONFIGURED, '1');
@@ -564,10 +582,7 @@ test('start blocks GitHub-only configuration and launches Compose with model acc
   assert.deepEqual(commands, [
     { command: 'docker', args: ['compose', 'up', '--build'], options: { cwd: project.rootDir, stdio: 'inherit' } },
   ]);
-  assert.equal(
-    (await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777,
-    0o700
-  );
+  assert.equal((await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777, 0o700);
 });
 
 test('start reports how to repair a Codex home parent left unwritable by Docker', async (t) => {


### PR DESCRIPTION
## What & why

Adds **OpenCode Zen** as a fourth model provider (`opencode`), alongside Codex, Claude, and OpenRouter. OpenCode Zen (https://opencode.ai/docs/zen/) is a curated AI gateway offering pay-per-use access to Claude, GPT-5.x-codex, and other models through a single API key — this lets users configure and run scans against it the same way they already do for OpenRouter.

Closes #30

Unlike OpenRouter, OpenCode Zen is not a single unified gateway: it exposes an Anthropic-compatible endpoint (serving `claude-*`/`qwen*` models) and a separate OpenAI Responses-API endpoint (serving `gpt-*`/`gpt-5.x-codex` models). This PR wires the Claude Code harness to the former and the Codex harness to the latter, and adds a clear configuration error when a harness/model-family pair is mismatched instead of an opaque upstream HTTP failure.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `chore` / `test` / `ci`
- [ ] Breaking change (`!` / `BREAKING CHANGE:`)

## Affected components

- [x] frontend
- [x] backend
- [x] engine
- [ ] database (migration)
- [x] docs / CI / tooling

(Also touches `executor-view`, the standalone account-status service, and `scripts/kritt-lib.mjs`/`kritt-ui.mjs`, the `./kritt` CLI — not listed as separate checkboxes above but included in the diff.)

## Checklist

- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (no empty `()` scope)
- [x] Commits are **signed off** (`git commit -s`) — DCO
- [x] Lint & format pass (`npm run lint` / `ruff check .`)
- [x] Tests added/updated and passing where it makes sense
- [x] Docs updated (new `docs-site/ai-provider-setup/opencode-zen.mdx`, `overview.mdx`, `.env.example`, `README.md`)
- [ ] For DB changes: N/A — no schema/migration change, only a documentation comment update in `schema.prisma`
- [x] No secrets committed

## Notes for reviewers

- **Model-family/harness coupling is new for this provider.** OpenRouter translates any model for either harness; OpenCode Zen does not, so `_claude_env`/`codex_exec_command` in `engine/open_kritt_engine/harnesses.py` now reject a mismatched harness/model pair with a clear `configuration_error` rather than letting the request fail upstream.
- **`executor-view/server.py` needed changes too.** This is the standalone service backing the Accounts page's per-provider status; without adding `opencode` to its routing allow-list and fetchers, the Accounts page's OpenCode Zen card would have shown a permanent load error. It has no documented key-info/usage endpoint like OpenRouter's, so it reports configuration status only, not live usage — flagged as a possible future enhancement if OpenCode Zen publishes one.
- **CLI menu renumbering**: inserting an "OpenCode Zen API key" item into `./kritt setup`'s numbered menu shifted "GitHub token" and "Finish setup" down by one. This is covered by updated tests in `scripts/kritt.test.mjs`.
- Out of scope, called out in the new docs page: OpenCode Zen's Grok/DeepSeek/GLM/Kimi/MiniMax/Gemini/free-tier models, which are served over wire formats neither harness speaks today. The catalog fetcher filters them out rather than surfacing them as broken choices.
- Test coverage: engine (pytest, all passing except 5 pre-existing unrelated failures also present on `main`), backend (149/149), frontend (215/215, plus a production build), CLI (37/37), executor-view (42/42, not part of the CI matrix but exercised locally), docs (`check-links` clean).
