### PR TITLE
docs: fix missing preposition 'in' in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -90,7 +90,7 @@ Releases are automated from [Conventional Commits](https://www.conventionalcommi
 - `feat!: …` / `BREAKING CHANGE:` → minor bump (pre-1.0)
 - `docs:`, `chore:`, `refactor:`, `test:`, `ci:` → no release on their own
 
-> **Scope is optional, but never use empty parentheses.** `feat():` is *invalid*
+> **Scope is optional, but never use empty parentheses.** `feat():` is *invalid in*
 > Conventional Commits and release-please silently skips it (`unexpected token ')'`).
 > Write `feat:` (no scope) or `feat(frontend):` (with a scope) — not `feat()`.
 


### PR DESCRIPTION
Fixes a grammar error on line 93-94 of RELEASE.md: the sentence "`feat():` is *invalid* Conventional Commits" is missing the preposition "in" before "Conventional Commits", making the sentence grammatically incorrect and semantically ambiguous.