### PR TITLE
feat: scale provider accounts and scan processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,13 @@ ENGINE_CODEX_HOME_SOURCE_HOST=./.data/codex-home-source
 # Container account list. Accounts and the CLI keep this synchronized with the
 # live runtime registry so added and removed logins survive future Compose runs.
 ENGINE_CODEX_HOME=/root/.codex
-ENGINE_CLAUDE_HOME=./.data/claude
+# Primary Claude login home. Existing .env files that use the legacy
+# ENGINE_CLAUDE_HOME name for this host path remain supported by Compose.
+ENGINE_CLAUDE_HOME_HOST=./.data/claude
+# Additional Claude logins created in Accounts live below this shared root.
+# Accounts updates the live runtime registry on add/remove; the engine picks up
+# the new list for future jobs without a container restart.
+ENGINE_CLAUDE_ACCOUNTS_HOST=./.data/claude-accounts
 ENGINE_POLL_SECONDS=5
 # Aggregate engine worker slots shared by scan steps and post-processing. Two is
 # a conservative default for a small 2-vCPU QA/developer machine; increase it
@@ -97,6 +103,9 @@ ENGINE_AUTOSCALE_SCAN_WORKERS_ON_PROVIDER_CAPACITY=true
 # Codex may run up to five child agents per scan session.
 ENGINE_CODEX_MAX_SUBAGENTS_PER_SESSION=5
 ENGINE_WORKSPACE_SETUP_CONCURRENCY=2
+# Compatibility name: this applies to workflow and post-processing jobs.
+# copy creates a host workspace per job; image builds one immutable scan snapshot and uses container COW.
+ENGINE_POST_PROCESS_WORKSPACE_MODE=copy
 ENGINE_RETRY_COUNT=2
 ENGINE_HARNESS_TIMEOUT_SECONDS=7200
 # Refresh account-specific provider model catalogs in the background.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-kritt-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-kritt-backend",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@prisma/client": "^5.22.0",

--- a/backend/prisma/migrate.js
+++ b/backend/prisma/migrate.js
@@ -32,18 +32,115 @@ function findSqlDir() {
   return null;
 }
 
-// Split a SQL file into individual statements. The init files use plain
-// statements (no functions / dollar-quoting), so splitting on top-level ';'
-// after stripping line comments is sufficient.
+// Split a SQL file into individual statements without treating semicolons or
+// comment markers inside quoted values as SQL syntax.
 function splitStatements(sql) {
-  const noComments = sql
-    .split('\n')
-    .map((line) => line.replace(/--.*$/, ''))
-    .join('\n');
-  return noComments
-    .split(';')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const statements = [];
+  let statement = '';
+  let state = 'normal';
+  let dollarTag = '';
+
+  for (let i = 0; i < sql.length; i += 1) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (state === 'line-comment') {
+      if (char === '\n') {
+        statement += char;
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        i += 1;
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'single-quote') {
+      statement += char;
+      if (char === "'" && next === "'") {
+        statement += next;
+        i += 1;
+      } else if (char === "'") {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'double-quote') {
+      statement += char;
+      if (char === '"' && next === '"') {
+        statement += next;
+        i += 1;
+      } else if (char === '"') {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'dollar-quote') {
+      if (sql.startsWith(dollarTag, i)) {
+        statement += dollarTag;
+        i += dollarTag.length - 1;
+        state = 'normal';
+      } else {
+        statement += char;
+      }
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      i += 1;
+      state = 'line-comment';
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      i += 1;
+      state = 'block-comment';
+      continue;
+    }
+
+    if (char === "'") {
+      statement += char;
+      state = 'single-quote';
+      continue;
+    }
+
+    if (char === '"') {
+      statement += char;
+      state = 'double-quote';
+      continue;
+    }
+
+    if (char === '$') {
+      const match = sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (match) {
+        dollarTag = match[0];
+        statement += dollarTag;
+        i += dollarTag.length - 1;
+        state = 'dollar-quote';
+        continue;
+      }
+    }
+
+    if (char === ';') {
+      const trimmed = statement.trim();
+      if (trimmed) statements.push(trimmed);
+      statement = '';
+      continue;
+    }
+
+    statement += char;
+  }
+
+  const trimmed = statement.trim();
+  if (trimmed) statements.push(trimmed);
+  return statements;
 }
 
 async function main() {

--- a/backend/src/lib/accountLogins.js
+++ b/backend/src/lib/accountLogins.js
@@ -9,7 +9,14 @@ import {
   parseEnvironmentText,
   updateEnvironmentFile,
 } from './environmentFile.js';
-import { CLAUDE_HOME, CODEX_ACCOUNTS_ROOT, CODEX_PRIMARY_HOME } from './providerLogins.js';
+import {
+  CLAUDE_ACCOUNTS_ROOT,
+  CLAUDE_HOME,
+  CLAUDE_RUNTIME_ACCOUNTS_ROOT,
+  CLAUDE_RUNTIME_PRIMARY_HOME,
+  CODEX_ACCOUNTS_ROOT,
+  CODEX_PRIMARY_HOME,
+} from './providerLogins.js';
 import { CLAUDE_CREDENTIAL_FILENAMES, promoteClaudeCredential, withClaudeCredentialLock } from './claudeCredentials.js';
 
 const LOGIN_PROVIDERS = new Set(['codex', 'claude']);
@@ -132,6 +139,50 @@ export async function removeCodexRuntimeHome(
   return true;
 }
 
+async function updateClaudeRuntimeHome(
+  home,
+  present,
+  { runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH, initialHomes = [CLAUDE_RUNTIME_PRIMARY_HOME] } = {}
+) {
+  let nextHomes = [];
+  const state = await mutateEnvironmentFile(
+    (values) => {
+      const homes = splitConfiguredHomes(
+        Object.hasOwn(values, 'ENGINE_CLAUDE_HOME') ? values.ENGINE_CLAUDE_HOME : initialHomes.join(',')
+      );
+      const updatedHomes = present
+        ? homes.includes(home)
+          ? homes
+          : [...homes, home]
+        : homes.filter((candidate) => candidate !== home);
+      nextHomes = updatedHomes;
+      return updatedHomes.length === homes.length
+        ? null
+        : {
+            ENGINE_CLAUDE_HOME: updatedHomes.join(','),
+          };
+    },
+    { environmentFilePath: runtimeConfigPath }
+  );
+  return { changed: state?.changed || false, homes: nextHomes };
+}
+
+export async function addClaudeRuntimeHome(
+  home,
+  { runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH, initialHomes } = {}
+) {
+  const state = await updateClaudeRuntimeHome(home, true, { runtimeConfigPath, initialHomes });
+  return state.homes;
+}
+
+export async function removeClaudeRuntimeHome(
+  home,
+  { runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH, initialHomes } = {}
+) {
+  const state = await updateClaudeRuntimeHome(home, false, { runtimeConfigPath, initialHomes });
+  return state.changed;
+}
+
 async function usableJsonFile(path) {
   try {
     const file = await stat(path);
@@ -168,12 +219,34 @@ async function codexReloginTarget(accountId, { primaryHome, primaryRuntimeHome, 
   return { home, runtimeHome: join(runtimeAccountsRoot, accountId, '.codex') };
 }
 
-async function claudeReloginTarget(accountId, home) {
+async function claudeReloginTarget(accountId, { primaryHome, primaryRuntimeHome, accountsRoot, runtimeAccountsRoot }) {
   if (!accountId) return null;
-  if (accountId !== 'default') throw loginError('Claude account not found.', 404);
+  let home;
+  let runtimeHome;
+  if (accountId === 'default') {
+    home = primaryHome;
+    runtimeHome = primaryRuntimeHome;
+  } else {
+    if (typeof accountId !== 'string' || !ACCOUNT_ID_PATTERN.test(accountId)) {
+      throw loginError('Claude account not found.', 404);
+    }
+    const resolvedAccountsRoot = resolve(accountsRoot);
+    const accountDirectory = resolve(resolvedAccountsRoot, accountId);
+    if (dirname(accountDirectory) !== resolvedAccountsRoot) throw loginError('Claude account not found.', 404);
+    try {
+      const entry = await lstat(accountDirectory);
+      if (!entry.isDirectory() || entry.isSymbolicLink()) throw loginError('Claude account not found.', 404);
+    } catch (error) {
+      if (error?.statusCode) throw error;
+      if (error?.code === 'ENOENT') throw loginError('Claude account not found.', 404);
+      throw error;
+    }
+    home = join(accountDirectory, '.claude');
+    runtimeHome = join(runtimeAccountsRoot, accountId, '.claude');
+  }
   const configured = await Promise.all(CLAUDE_CREDENTIAL_FILENAMES.map((name) => usableJsonFile(join(home, name))));
   if (!configured.some(Boolean)) throw loginError('Claude account not found.', 404);
-  return { home };
+  return { home, runtimeHome };
 }
 
 function publicSession(session) {
@@ -211,6 +284,9 @@ export class AccountLoginManager {
     codexRuntimePrimaryHome = CODEX_RUNTIME_PRIMARY_HOME,
     codexRuntimeAccountsRoot = CODEX_RUNTIME_ACCOUNTS_ROOT,
     claudeHome = CLAUDE_HOME,
+    claudeAccountsRoot = CLAUDE_ACCOUNTS_ROOT,
+    claudeRuntimePrimaryHome = CLAUDE_RUNTIME_PRIMARY_HOME,
+    claudeRuntimeAccountsRoot = CLAUDE_RUNTIME_ACCOUNTS_ROOT,
     runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH,
     environmentFilePath = PROJECT_ENV_FILE_PATH,
     timeoutMs = SESSION_TIMEOUT_MS,
@@ -221,6 +297,9 @@ export class AccountLoginManager {
     this.codexRuntimePrimaryHome = codexRuntimePrimaryHome;
     this.codexRuntimeAccountsRoot = codexRuntimeAccountsRoot;
     this.claudeHome = claudeHome;
+    this.claudeAccountsRoot = claudeAccountsRoot;
+    this.claudeRuntimePrimaryHome = claudeRuntimePrimaryHome;
+    this.claudeRuntimeAccountsRoot = claudeRuntimeAccountsRoot;
     this.runtimeConfigPath = runtimeConfigPath;
     this.environmentFilePath = environmentFilePath;
     this.timeoutMs = timeoutMs;
@@ -242,7 +321,12 @@ export class AccountLoginManager {
             accountsRoot: this.codexAccountsRoot,
             runtimeAccountsRoot: this.codexRuntimeAccountsRoot,
           })
-        : await claudeReloginTarget(accountId, this.claudeHome);
+        : await claudeReloginTarget(accountId, {
+            primaryHome: this.claudeHome,
+            primaryRuntimeHome: this.claudeRuntimePrimaryHome,
+            accountsRoot: this.claudeAccountsRoot,
+            runtimeAccountsRoot: this.claudeRuntimeAccountsRoot,
+          });
 
     const id = randomUUID();
     const createdAt = new Date();
@@ -278,7 +362,17 @@ export class AccountLoginManager {
       args = ['login', '--device-auth'];
       env.CODEX_HOME = session.codexHome;
     } else {
-      if (reloginTarget) session.replacesAccountId = accountId;
+      if (reloginTarget) {
+        session.claudeHome = reloginTarget.home;
+        session.claudeRuntimeHome = reloginTarget.runtimeHome;
+        session.replacesAccountId = accountId;
+      } else {
+        const folder = `account-${createdAt.toISOString().replace(/\D/g, '').slice(0, 14)}-${id.slice(0, 8)}`;
+        session.claudeDirectory = join(this.claudeAccountsRoot, folder);
+        session.claudeHome = join(session.claudeDirectory, '.claude');
+        session.claudeRuntimeHome = join(this.claudeRuntimeAccountsRoot, folder, '.claude');
+        await mkdir(session.claudeHome, { recursive: true, mode: 0o700 });
+      }
       session.claudeLoginHome = join(dirname(this.claudeHome), `.claude-login-${id}`);
       await mkdir(session.claudeLoginHome, { recursive: true, mode: 0o700 });
       command = 'claude';
@@ -295,6 +389,7 @@ export class AccountLoginManager {
     } catch (error) {
       session.status = 'failed';
       session.message = `Could not start ${provider} login: ${error.message}`;
+      if (session.claudeDirectory) void rm(session.claudeDirectory, { recursive: true, force: true });
       if (session.claudeLoginHome) void rm(session.claudeLoginHome, { recursive: true, force: true });
       throw loginError(session.message, 503);
     }
@@ -442,12 +537,25 @@ export class AccountLoginManager {
     if (activeForProvider) throw loginError(`Finish or cancel the ${provider} login before removing an account.`, 409);
 
     if (provider === 'claude') {
-      if (accountId !== 'default') throw loginError('Claude account not found.', 404);
-      const removed = await withClaudeCredentialLock(this.claudeHome, async () => {
+      const target = await claudeReloginTarget(accountId, {
+        primaryHome: this.claudeHome,
+        primaryRuntimeHome: this.claudeRuntimePrimaryHome,
+        accountsRoot: this.claudeAccountsRoot,
+        runtimeAccountsRoot: this.claudeRuntimeAccountsRoot,
+      });
+      const configured = await removeClaudeRuntimeHome(target.runtimeHome, {
+        runtimeConfigPath: this.runtimeConfigPath,
+      });
+      if (!configured) throw loginError('Claude account not found.', 404);
+      if (accountId !== 'default') {
+        await rm(dirname(target.home), { recursive: true });
+        return { provider, accountId, removed: true };
+      }
+      const removed = await withClaudeCredentialLock(target.home, async () => {
         let found = false;
         for (const name of CLAUDE_CREDENTIAL_FILENAMES) {
           try {
-            await rm(join(this.claudeHome, name));
+            await rm(join(target.home, name));
             found = true;
           } catch (error) {
             if (error?.code !== 'ENOENT') throw error;
@@ -501,6 +609,7 @@ export class AccountLoginManager {
     session.message = message;
     session.child = null;
     if (session.codexDirectory) void rm(session.codexDirectory, { recursive: true, force: true });
+    if (session.claudeDirectory) void rm(session.claudeDirectory, { recursive: true, force: true });
     if (session.claudeLoginHome) void rm(session.claudeLoginHome, { recursive: true, force: true });
   }
 
@@ -511,6 +620,7 @@ export class AccountLoginManager {
       clearTimeout(session.timeout);
       session.child = null;
       if (session.codexDirectory) await rm(session.codexDirectory, { recursive: true, force: true });
+      if (session.claudeDirectory) await rm(session.claudeDirectory, { recursive: true, force: true });
       if (session.claudeLoginHome) await rm(session.claudeLoginHome, { recursive: true, force: true });
       return;
     }
@@ -528,7 +638,7 @@ export class AccountLoginManager {
       const usable =
         session.provider === 'codex'
           ? await usableJsonFile(join(session.codexHome, 'auth.json'))
-          : await promoteClaudeCredential(session.claudeLoginHome, this.claudeHome);
+          : await promoteClaudeCredential(session.claudeLoginHome, session.claudeHome || this.claudeHome);
       if (!usable) throw new Error('The provider finished without saving usable login credentials.');
       if (session.provider === 'codex') {
         if (!(await usableJsonFile(join(this.codexPrimaryHome, 'auth.json')))) {
@@ -541,6 +651,18 @@ export class AccountLoginManager {
           runtimeConfigPath: this.runtimeConfigPath,
           environmentFilePath: this.environmentFilePath,
         });
+      } else if (session.claudeRuntimeHome) {
+        const primaryCredentials = await Promise.all(
+          CLAUDE_CREDENTIAL_FILENAMES.map((name) => usableJsonFile(join(this.claudeHome, name)))
+        );
+        if (!primaryCredentials.some(Boolean)) {
+          await removeClaudeRuntimeHome(this.claudeRuntimePrimaryHome, {
+            runtimeConfigPath: this.runtimeConfigPath,
+          });
+        }
+        await addClaudeRuntimeHome(session.claudeRuntimeHome, {
+          runtimeConfigPath: this.runtimeConfigPath,
+        });
       }
       session.status = 'completed';
       session.message = sessionMessage(session.provider, 'completed', {});
@@ -548,6 +670,7 @@ export class AccountLoginManager {
       session.status = 'failed';
       session.message = error.message;
       if (session.codexDirectory) await rm(session.codexDirectory, { recursive: true, force: true });
+      if (session.claudeDirectory) await rm(session.claudeDirectory, { recursive: true, force: true });
     } finally {
       if (session.claudeLoginHome) await rm(session.claudeLoginHome, { recursive: true, force: true });
       session.settled = true;

--- a/backend/src/lib/accounts.js
+++ b/backend/src/lib/accounts.js
@@ -1,8 +1,9 @@
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { renewClaudeCredential } from './claudeCredentials.js';
 import { providerCredentialStatuses } from './providerCredentials.js';
-import { CLAUDE_HOME } from './providerLogins.js';
+import { CLAUDE_ACCOUNTS_ROOT, CLAUDE_HOME } from './providerLogins.js';
 
 const EXECUTOR_VIEW_URL = process.env.EXECUTOR_VIEW_URL || 'http://executor-view:8090';
 const EXECUTOR_VIEW_INTERNAL_TOKEN_FILE =
@@ -10,6 +11,7 @@ const EXECUTOR_VIEW_INTERNAL_TOKEN_FILE =
 const ACCOUNT_PROVIDER_IDS = ['codex', 'claude', 'openrouter'];
 const EXECUTOR_ACCOUNT_TIMEOUT_MS = 180000;
 const ACCOUNT_STATUS_KINDS = new Set(['available', 'limited', 'stale', 'expired', 'warning', 'missing']);
+const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 function safeText(value, limit = 500) {
   return typeof value === 'string' ? value.slice(0, limit) : null;
@@ -151,6 +153,7 @@ export async function fetchExecutorProvider(
     internalTokenFile,
     timeoutMs = EXECUTOR_ACCOUNT_TIMEOUT_MS,
     claudeHome = CLAUDE_HOME,
+    claudeAccountsRoot = CLAUDE_ACCOUNTS_ROOT,
     renewClaudeLogin = renewClaudeCredential,
   } = {}
 ) {
@@ -176,10 +179,21 @@ export async function fetchExecutorProvider(
       providerId === 'claude' && refresh && provider?.accounts?.some((account) => account?.statusKind === 'expired');
     if (claudeLoginRejected) {
       let renewed = false;
-      try {
-        renewed = await renewClaudeLogin(claudeHome);
-      } catch {
-        // Preserve the sanitized sign-in response when local renewal cannot run.
+      const homes = new Set(
+        provider.accounts
+          .filter((account) => account?.statusKind === 'expired')
+          .map((account) => {
+            if (!account?.id || account.id === 'default') return claudeHome;
+            return ACCOUNT_ID_PATTERN.test(account?.id || '') ? join(claudeAccountsRoot, account.id, '.claude') : null;
+          })
+          .filter(Boolean)
+      );
+      for (const home of homes) {
+        try {
+          renewed = (await renewClaudeLogin(home)) || renewed;
+        } catch {
+          // Preserve the sanitized sign-in response when local renewal cannot run.
+        }
       }
       if (renewed) provider = await requestProvider();
     }
@@ -195,6 +209,7 @@ export async function fetchExecutorAccounts({
   internalToken,
   internalTokenFile,
   claudeHome,
+  claudeAccountsRoot,
   renewClaudeLogin,
 } = {}) {
   const providers = await Promise.all(
@@ -205,6 +220,7 @@ export async function fetchExecutorAccounts({
         internalToken,
         internalTokenFile,
         claudeHome,
+        claudeAccountsRoot,
         renewClaudeLogin,
       })
     )

--- a/backend/src/lib/claudeCredentials.js
+++ b/backend/src/lib/claudeCredentials.js
@@ -5,9 +5,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 export const CLAUDE_CREDENTIAL_FILENAMES = ['.credentials.json', 'credentials.json'];
+export const CLAUDE_ACCOUNT_PROFILE_FILENAME = '.open-kritt-account.json';
 export const CLAUDE_AUTH_LOCK_NAME = '.open-kritt-auth.lock';
 
 const MAX_CREDENTIAL_BYTES = 1024 * 1024;
+const CLAUDE_PROFILE_FILENAMES = ['.claude.json', 'claude.json'];
 const LOCK_WAIT_MS = 30_000;
 const STALE_LOCK_MS = 30 * 60 * 1000;
 const CLAUDE_REFRESH_TIMEOUT_MS = 120_000;
@@ -238,9 +240,73 @@ export async function renewClaudeCredential(home, { now = Date.now, runProbe = r
   });
 }
 
+function firstProfileValue(value, keys, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return null;
+  seen.add(value);
+  for (const [key, candidate] of Object.entries(value)) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (keys.has(normalizedKey) && (typeof candidate === 'string' || typeof candidate === 'number')) {
+      const text = String(candidate).trim();
+      if (text) return text;
+    }
+  }
+  for (const candidate of Object.values(value)) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const found = firstProfileValue(candidate, keys, seen);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function readClaudeAccountProfile(home) {
+  for (const name of CLAUDE_PROFILE_FILENAMES) {
+    const path = join(home, name);
+    try {
+      const file = await lstat(path);
+      if (file.isSymbolicLink() || !file.isFile() || file.size > MAX_CREDENTIAL_BYTES) continue;
+      const payload = JSON.parse(await readFile(path, 'utf8'));
+      const profile = {
+        provider: 'claude',
+        accountId: firstProfileValue(payload, new Set(['accountid', 'accountuuid', 'userid', 'useruuid'])),
+        email: firstProfileValue(payload, new Set(['email', 'emailaddress', 'useremail', 'accountemail'])),
+        name: firstProfileValue(payload, new Set(['name', 'username', 'displayname'])),
+        organization: firstProfileValue(
+          payload,
+          new Set(['organization', 'organizationname', 'organizationid', 'organizationuuid', 'orgid'])
+        ),
+      };
+      if (profile.accountId || profile.email || profile.name || profile.organization) return profile;
+    } catch (error) {
+      if (error?.code === 'ENOENT' || error instanceof SyntaxError) continue;
+      throw error;
+    }
+  }
+  return null;
+}
+
+async function writeClaudeAccountProfile(home, profile) {
+  if (!profile) return;
+  const targetPath = join(home, CLAUDE_ACCOUNT_PROFILE_FILENAME);
+  const temporaryPath = join(home, `.${CLAUDE_ACCOUNT_PROFILE_FILENAME}.${process.pid}.${randomUUID()}.tmp`);
+  let temporary;
+  try {
+    temporary = await open(temporaryPath, 'wx', 0o600);
+    await temporary.writeFile(`${JSON.stringify(profile, null, 2)}\n`);
+    await temporary.sync();
+    await temporary.close();
+    temporary = null;
+    await rename(temporaryPath, targetPath);
+    await chmod(targetPath, 0o600);
+  } finally {
+    await temporary?.close().catch(() => {});
+    await rm(temporaryPath, { force: true }).catch(() => {});
+  }
+}
+
 export async function promoteClaudeCredential(sourceHome, targetHome) {
   const credential = await readClaudeCredential(sourceHome);
   if (!credential) throw new Error('The provider finished without saving usable login credentials.');
+  const accountProfile = await readClaudeAccountProfile(sourceHome);
 
   return withClaudeCredentialLock(targetHome, async () => {
     const targetName = CLAUDE_CREDENTIAL_FILENAMES[0];
@@ -258,6 +324,7 @@ export async function promoteClaudeCredential(sourceHome, targetHome) {
       for (const name of CLAUDE_CREDENTIAL_FILENAMES) {
         if (name !== targetName) await rm(join(targetHome, name), { force: true });
       }
+      await writeClaudeAccountProfile(targetHome, accountProfile);
       return targetPath;
     } finally {
       await temporary?.close().catch(() => {});

--- a/backend/src/lib/providerCredentials.js
+++ b/backend/src/lib/providerCredentials.js
@@ -21,7 +21,7 @@ export const PROVIDER_DEFINITIONS = {
     label: 'Claude',
     envKeys: ['ANTHROPIC_API_KEY'],
     credentialLabel: 'Claude login',
-    description: 'Claude subscription account authenticated through Claude Code.',
+    description: 'Claude subscription accounts authenticated through Claude Code.',
     management: 'login',
   },
   openrouter: {

--- a/backend/src/lib/providerLogins.js
+++ b/backend/src/lib/providerLogins.js
@@ -4,11 +4,15 @@ import { join, relative } from 'node:path';
 export const CODEX_PRIMARY_HOME = process.env.OPEN_KRITT_CODEX_HOME_DIR || '/provider-homes/codex';
 export const CODEX_ACCOUNTS_ROOT = process.env.OPEN_KRITT_CODEX_ACCOUNTS_DIR || '/provider-homes/codex-accounts';
 export const CLAUDE_HOME = process.env.OPEN_KRITT_CLAUDE_HOME || '/provider-homes/claude';
-const CODEX_RUNTIME_CONFIG_PATH =
+export const CLAUDE_ACCOUNTS_ROOT = process.env.OPEN_KRITT_CLAUDE_ACCOUNTS_DIR || '/provider-homes/claude-accounts';
+const ENGINE_RUNTIME_CONFIG_PATH =
   process.env.OPEN_KRITT_ENGINE_RUNTIME_CONFIG_PATH || '/engine-data/engine-runtime.env';
 const CODEX_RUNTIME_PRIMARY_HOME = process.env.OPEN_KRITT_CODEX_RUNTIME_PRIMARY_HOME || '/root/.codex';
 const CODEX_RUNTIME_ACCOUNTS_ROOT = process.env.OPEN_KRITT_CODEX_RUNTIME_ACCOUNTS_DIR || '/codex-accounts';
 const CODEX_INITIAL_HOME = process.env.OPEN_KRITT_CODEX_INITIAL_HOME || CODEX_RUNTIME_PRIMARY_HOME;
+export const CLAUDE_RUNTIME_PRIMARY_HOME = process.env.OPEN_KRITT_CLAUDE_RUNTIME_PRIMARY_HOME || '/root/.claude';
+export const CLAUDE_RUNTIME_ACCOUNTS_ROOT = process.env.OPEN_KRITT_CLAUDE_RUNTIME_ACCOUNTS_DIR || '/claude-accounts';
+const CLAUDE_INITIAL_HOME = process.env.OPEN_KRITT_CLAUDE_INITIAL_HOME || CLAUDE_RUNTIME_PRIMARY_HOME;
 const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 function readableJsonObject(path) {
@@ -41,9 +45,9 @@ function splitConfiguredHomes(value) {
     .filter(Boolean);
 }
 
-function configuredRuntimeHomes(runtimeConfigPath, initialHome) {
+function configuredRuntimeHomes(runtimeConfigPath, key, initialHome) {
   try {
-    const configured = runtimeValue(readFileSync(runtimeConfigPath, 'utf8'), 'ENGINE_CODEX_HOME');
+    const configured = runtimeValue(readFileSync(runtimeConfigPath, 'utf8'), key);
     if (configured !== null) return splitConfiguredHomes(configured);
   } catch {
     // The engine creates the runtime file on first start. Until then, .env is
@@ -55,12 +59,12 @@ function configuredRuntimeHomes(runtimeConfigPath, initialHome) {
 export function codexLoginIsConfigured({
   primaryHome = CODEX_PRIMARY_HOME,
   accountsRoot = CODEX_ACCOUNTS_ROOT,
-  runtimeConfigPath = CODEX_RUNTIME_CONFIG_PATH,
+  runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH,
   runtimePrimaryHome = CODEX_RUNTIME_PRIMARY_HOME,
   runtimeAccountsRoot = CODEX_RUNTIME_ACCOUNTS_ROOT,
   initialHome = CODEX_INITIAL_HOME,
 } = {}) {
-  const homes = configuredRuntimeHomes(runtimeConfigPath, initialHome).map((runtimeHome) => {
+  const homes = configuredRuntimeHomes(runtimeConfigPath, 'ENGINE_CODEX_HOME', initialHome).map((runtimeHome) => {
     if (runtimeHome === runtimePrimaryHome) return primaryHome;
     const accountPath = relative(runtimeAccountsRoot, runtimeHome);
     const parts = accountPath.split(/[\\/]/);
@@ -70,10 +74,28 @@ export function codexLoginIsConfigured({
   return homes.filter(Boolean).some((home) => readableJsonObject(join(home, 'auth.json')));
 }
 
-export function claudeLoginIsConfigured({ home = CLAUDE_HOME } = {}) {
+export function claudeLoginIsConfigured({
+  home = CLAUDE_HOME,
+  accountsRoot = CLAUDE_ACCOUNTS_ROOT,
+  runtimeConfigPath = ENGINE_RUNTIME_CONFIG_PATH,
+  runtimePrimaryHome = CLAUDE_RUNTIME_PRIMARY_HOME,
+  runtimeAccountsRoot = CLAUDE_RUNTIME_ACCOUNTS_ROOT,
+  initialHome = CLAUDE_INITIAL_HOME,
+} = {}) {
   // Profile metadata lives in .claude.json, but a usable container login also
   // needs the OAuth credential file written by `claude auth login`.
-  return ['.credentials.json', 'credentials.json'].some((name) => readableJsonObject(join(home, name)));
+  const homes = configuredRuntimeHomes(runtimeConfigPath, 'ENGINE_CLAUDE_HOME', initialHome).map((runtimeHome) => {
+    if (runtimeHome === runtimePrimaryHome) return home;
+    const accountPath = relative(runtimeAccountsRoot, runtimeHome);
+    const parts = accountPath.split(/[\\/]/);
+    if (parts.length !== 2 || parts[1] !== '.claude' || !ACCOUNT_ID_PATTERN.test(parts[0])) return null;
+    return join(accountsRoot, parts[0], '.claude');
+  });
+  return homes
+    .filter(Boolean)
+    .some((candidate) =>
+      ['.credentials.json', 'credentials.json'].some((name) => readableJsonObject(join(candidate, name)))
+    );
 }
 
 export function providerLoginIsConfigured(provider, options = {}) {

--- a/backend/src/lib/serialize.js
+++ b/backend/src/lib/serialize.js
@@ -316,6 +316,11 @@ export function serializeScan(
     modelProvider: scan.modelProvider ?? null,
     harness: scan.harness,
     thinkingEffort: scan.thinkingEffort ?? null,
+    postProcessingThinkingEffort:
+      scan.configuration?.post_processing_thinking_effort ??
+      scan.configuration?.postProcessingThinkingEffort ??
+      scan.thinkingEffort ??
+      null,
     modelOverrides: serializeModelOverrides(scan.modelOverrides),
     status: scan.status,
     workflowId: scan.workflowId.toString(),

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -113,6 +113,30 @@ export function validateModelSelection(body) {
   return normalized;
 }
 
+export function validatePostProcessingThinkingEffort(value, { harness, fallback = DEFAULT_THINKING_EFFORT } = {}) {
+  const field = 'post_processing_thinking_effort';
+  if (value != null && typeof value !== 'string') {
+    throw new ValidationError([{ field, message: 'Post-processing thinking effort must be a string.' }]);
+  }
+  const normalizedFallback =
+    typeof fallback === 'string' && fallback.trim() ? fallback.trim() : DEFAULT_THINKING_EFFORT;
+  const effort = typeof value === 'string' && value.trim() ? value.trim() : normalizedFallback;
+  if (!THINKING_EFFORTS.includes(effort)) {
+    throw new ValidationError([
+      { field, message: `Post-processing thinking effort must be one of: ${THINKING_EFFORTS.join(', ')}.` },
+    ]);
+  }
+  if (HARNESSES.includes(harness) && !HARNESS_THINKING_EFFORTS[harness]?.includes(effort)) {
+    throw new ValidationError([
+      {
+        field,
+        message: `Post-processing thinking effort "${effort}" is not supported by harness "${harness}".`,
+      },
+    ]);
+  }
+  return effort;
+}
+
 export function validateModelOverrides(value, { allowedDepths = null, field = 'model_overrides' } = {}) {
   if (value === undefined || value === null) return {};
   if (!isObjectMap(value)) {
@@ -718,6 +742,22 @@ export function validateScan(body, { localNames = null } = {}) {
       push('configuration', 'Configuration is not valid JSON.');
     }
   }
+  let postProcessingThinkingEffort = selection.normalized.thinkingEffort;
+  try {
+    const configuredPostProcessingThinkingEffort =
+      body?.post_processing_thinking_effort ??
+      body?.postProcessingThinkingEffort ??
+      (configuration && typeof configuration === 'object' && !Array.isArray(configuration)
+        ? (configuration.post_processing_thinking_effort ?? configuration.postProcessingThinkingEffort)
+        : undefined);
+    postProcessingThinkingEffort = validatePostProcessingThinkingEffort(configuredPostProcessingThinkingEffort, {
+      harness: selection.normalized.harness,
+      fallback: selection.normalized.thinkingEffort,
+    });
+  } catch (error) {
+    if (error instanceof ValidationError) errors.push(...error.errors);
+    else throw error;
+  }
 
   // severity_ranker: required concatenated markdown ruleset for ranking findings.
   const severityRanker = (body?.severity_ranker ?? body?.severityRanker ?? '').toString();
@@ -747,6 +787,7 @@ export function validateScan(body, { localNames = null } = {}) {
     dependencies, // [{ kind, repoFull, commitSha }]
     configuration,
     ...selection.normalized,
+    postProcessingThinkingEffort,
     modelOverrides,
     severityRanker,
     extra,
@@ -765,10 +806,19 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
   const hasProvider = hasOwn('model_provider') || hasOwn('modelProvider');
   const hasHarness = hasOwn('harness');
   const hasThinkingEffort = hasOwn('thinking_effort') || hasOwn('thinkingEffort');
+  const hasPostProcessingThinkingEffort =
+    hasOwn('post_processing_thinking_effort') || hasOwn('postProcessingThinkingEffort');
   const hasModelOverrides = hasOwn('model_overrides') || hasOwn('modelOverrides');
 
-  if (!hasModel && !hasProvider && !hasHarness && !hasThinkingEffort && !hasModelOverrides) {
-    return { data, selection: null, modelOverrides: null };
+  if (
+    !hasModel &&
+    !hasProvider &&
+    !hasHarness &&
+    !hasThinkingEffort &&
+    !hasPostProcessingThinkingEffort &&
+    !hasModelOverrides
+  ) {
+    return { data, selection: null, postProcessingSelection: null, modelOverrides: null };
   }
 
   const selection =
@@ -780,6 +830,37 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
           thinking_effort: hasThinkingEffort ? (body?.thinking_effort ?? body?.thinkingEffort) : current.thinkingEffort,
         })
       : null;
+  const prospectiveSelection =
+    selection ||
+    validateModelSelection({
+      model: current.model,
+      model_provider: current.modelProvider,
+      harness: current.harness,
+      thinking_effort: current.thinkingEffort,
+    });
+  const currentConfiguration =
+    current.configuration && typeof current.configuration === 'object' && !Array.isArray(current.configuration)
+      ? current.configuration
+      : {};
+  const explicitCurrentPostProcessingThinkingEffort =
+    current.postProcessingThinkingEffort ??
+    currentConfiguration.post_processing_thinking_effort ??
+    currentConfiguration.postProcessingThinkingEffort;
+  const currentPostProcessingThinkingEffort =
+    explicitCurrentPostProcessingThinkingEffort ?? prospectiveSelection.thinkingEffort;
+  const postProcessingThinkingEffort = validatePostProcessingThinkingEffort(
+    hasPostProcessingThinkingEffort
+      ? (body?.post_processing_thinking_effort ?? body?.postProcessingThinkingEffort)
+      : currentPostProcessingThinkingEffort,
+    {
+      harness: prospectiveSelection.harness,
+      fallback: prospectiveSelection.thinkingEffort,
+    }
+  );
+  const postProcessingSelection =
+    selection || hasPostProcessingThinkingEffort
+      ? { ...prospectiveSelection, thinkingEffort: postProcessingThinkingEffort }
+      : null;
   const modelOverrides = hasModelOverrides
     ? validateModelOverrides(body?.model_overrides ?? body?.modelOverrides, { allowedDepths })
     : null;
@@ -788,7 +869,8 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
   if (hasProvider) data.modelProvider = selection.modelProvider;
   if (hasHarness) data.harness = selection.harness;
   if (hasThinkingEffort) data.thinkingEffort = selection.thinkingEffort;
+  if (hasPostProcessingThinkingEffort) data.postProcessingThinkingEffort = postProcessingThinkingEffort;
   if (hasModelOverrides) data.modelOverrides = modelOverrides;
 
-  return { data, selection, modelOverrides };
+  return { data, selection, postProcessingSelection, modelOverrides };
 }

--- a/backend/src/routes/scans.js
+++ b/backend/src/routes/scans.js
@@ -154,7 +154,7 @@ export async function assertModelOverridesAvailable(modelOverrides, assertAvaila
 
 export async function validateScanRuntimeUpdate(body, current, { assertAvailable, allowedDepths = null } = {}) {
   const runtime = validateProspectiveScanRuntimeSettings(body, current, { allowedDepths });
-  if (!runtime.selection && runtime.modelOverrides === null) return {};
+  if (!runtime.selection && !runtime.postProcessingSelection && runtime.modelOverrides === null) return {};
   if (typeof assertAvailable !== 'function') {
     throw new TypeError('Runtime model availability validation requires a transaction-aware checker.');
   }
@@ -167,6 +167,15 @@ export async function validateScanRuntimeUpdate(body, current, { assertAvailable
       harness: runtime.selection.harness,
       thinkingEffort: runtime.selection.thinkingEffort,
     });
+  }
+  if (
+    runtime.postProcessingSelection &&
+    JSON.stringify(runtime.postProcessingSelection) !== JSON.stringify(runtime.selection)
+  ) {
+    await assertSelectionAvailable(assertAvailable, runtime.postProcessingSelection, 'post_processing');
+  }
+  if (Object.prototype.hasOwnProperty.call(runtime.data, 'postProcessingThinkingEffort')) {
+    data.postProcessingThinkingEffort = runtime.data.postProcessingThinkingEffort;
   }
   if (runtime.modelOverrides !== null) {
     await assertModelOverridesAvailable(runtime.modelOverrides, assertAvailable);
@@ -231,13 +240,20 @@ export async function patchScanIfPresent(tx, scanId, body, { assertAvailable, av
     Object.prototype.hasOwnProperty.call(body, 'model_overrides') ||
     Object.prototype.hasOwnProperty.call(body, 'modelOverrides');
   const allowedDepths = hasModelOverrides ? await scanWorkflowDepths(tx, existing.workflowId) : null;
-  Object.assign(
-    data,
-    await validateScanRuntimeUpdate(body, existing, {
-      assertAvailable: availabilityChecker,
-      allowedDepths,
-    })
-  );
+  const runtimeData = await validateScanRuntimeUpdate(body, existing, {
+    assertAvailable: availabilityChecker,
+    allowedDepths,
+  });
+  if (Object.prototype.hasOwnProperty.call(runtimeData, 'postProcessingThinkingEffort')) {
+    data.configuration = {
+      ...(existing.configuration && typeof existing.configuration === 'object' && !Array.isArray(existing.configuration)
+        ? existing.configuration
+        : {}),
+      post_processing_thinking_effort: runtimeData.postProcessingThinkingEffort,
+    };
+    delete runtimeData.postProcessingThinkingEffort;
+  }
+  Object.assign(data, runtimeData);
   if (Object.keys(data).length === 0) {
     throw new ValidationError([{ field: 'scan', message: 'Provide a status or runtime setting to update.' }]);
   }
@@ -363,6 +379,10 @@ router.post('/', async (req, res, next) => {
   try {
     const valid = validateScan(req.body, { localNames: localRepoNames() });
     await assertModelSelectionAvailable(valid);
+    await assertModelSelectionAvailable({
+      ...valid,
+      thinkingEffort: valid.postProcessingThinkingEffort,
+    });
     const activeScanCount = await prisma.scan.count({ where: { status: { in: ACTIVE_SCAN_STATUSES } } });
     const launchDecision = scanLaunchDecision(req.body, activeScanCount);
     if (launchDecision.kind === 'choice-required') {
@@ -510,6 +530,7 @@ router.post('/', async (req, res, next) => {
             ...configurationObject,
             post_script_ids: configuredPostScriptIds,
             agent_skill_ids: configuredAgentSkillIds,
+            post_processing_thinking_effort: valid.postProcessingThinkingEffort,
           },
           model: valid.model,
           modelProvider: valid.modelProvider,

--- a/backend/test/accountLogins.test.js
+++ b/backend/test/accountLogins.test.js
@@ -7,8 +7,10 @@ import { test } from 'node:test';
 
 import {
   AccountLoginManager,
+  addClaudeRuntimeHome,
   addCodexRuntimeHome,
   parseLoginInstructions,
+  removeClaudeRuntimeHome,
   removeCodexRuntimeHome,
   stripTerminalFormatting,
 } from '../src/lib/accountLogins.js';
@@ -75,6 +77,22 @@ test('Codex runtime registry is seeded from .env when its live file is missing',
   const expected = '/codex-accounts/existing/.codex,/codex-accounts/new/.codex';
   assert.match(await readFile(runtimeConfigPath, 'utf8'), new RegExp(`^ENGINE_CODEX_HOME=${expected}$`, 'm'));
   assert.equal(parseEnvironmentText(await readFile(environmentFilePath, 'utf8')).ENGINE_CODEX_HOME, expected);
+});
+
+test('Claude login is added to the live runtime registry idempotently', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'open-kritt-claude-runtime-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const runtimeConfigPath = join(directory, 'engine-runtime.env');
+  await writeFile(runtimeConfigPath, 'ENGINE_WORKER_COUNT=4\nENGINE_CLAUDE_HOME=/root/.claude\n');
+
+  await addClaudeRuntimeHome('/claude-accounts/reviewer/.claude', { runtimeConfigPath });
+  await addClaudeRuntimeHome('/claude-accounts/reviewer/.claude', { runtimeConfigPath });
+  assert.equal(await removeClaudeRuntimeHome('/claude-accounts/missing/.claude', { runtimeConfigPath }), false);
+
+  const text = await readFile(runtimeConfigPath, 'utf8');
+  assert.match(text, /^ENGINE_WORKER_COUNT=4$/m);
+  assert.match(text, /^ENGINE_CLAUDE_HOME=\/root\/\.claude,\/claude-accounts\/reviewer\/\.claude$/m);
+  assert.equal((text.match(/\/claude-accounts\/reviewer\/\.claude/g) || []).length, 1);
 });
 
 test('failed .env persistence does not leave an orphaned Codex login', async (t) => {
@@ -361,7 +379,9 @@ test('Claude account removal signs out without deleting profile settings', async
   await mkdir(claudeHome, { recursive: true });
   await writeFile(join(claudeHome, '.credentials.json'), '{"claudeAiOauth":{"accessToken":"test"}}');
   await writeFile(join(claudeHome, '.claude.json'), '{"theme":"dark"}');
-  const manager = new AccountLoginManager({ claudeHome });
+  const runtimeConfigPath = join(directory, 'engine-runtime.env');
+  await writeFile(runtimeConfigPath, 'ENGINE_CLAUDE_HOME=/root/.claude\n');
+  const manager = new AccountLoginManager({ claudeHome, runtimeConfigPath });
 
   assert.deepEqual(await manager.removeAccount('claude', 'default'), {
     provider: 'claude',
@@ -370,6 +390,108 @@ test('Claude account removal signs out without deleting profile settings', async
   });
   await assert.rejects(stat(join(claudeHome, '.credentials.json')), { code: 'ENOENT' });
   assert.equal(await readFile(join(claudeHome, '.claude.json'), 'utf8'), '{"theme":"dark"}');
+  assert.match(await readFile(runtimeConfigPath, 'utf8'), /^ENGINE_CLAUDE_HOME=$/m);
+});
+
+test('adding a Claude account creates a distinct managed home and registers it for rotation', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'open-kritt-login-add-claude-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const claudeHome = join(directory, 'claude-primary');
+  const claudeAccountsRoot = join(directory, 'claude-accounts');
+  const runtimeConfigPath = join(directory, 'engine-runtime.env');
+  await mkdir(claudeHome, { recursive: true });
+  await writeFile(runtimeConfigPath, 'ENGINE_CLAUDE_HOME=/root/.claude\n');
+  let invocation;
+  const manager = new AccountLoginManager({
+    claudeHome,
+    claudeAccountsRoot,
+    claudeRuntimeAccountsRoot: '/runtime-claude-accounts',
+    runtimeConfigPath,
+    spawnProcess(command, args, options) {
+      invocation = { command, args, options };
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = {};
+      child.kill = () => {};
+      return child;
+    },
+  });
+
+  const publicSession = await manager.start('claude');
+  const session = manager.sessions.get(publicSession.id);
+  await writeFile(
+    join(session.claudeLoginHome, '.credentials.json'),
+    '{"claudeAiOauth":{"accessToken":"new","refreshToken":"refresh","expiresAt":9999999999999}}'
+  );
+  await writeFile(
+    join(session.claudeLoginHome, '.claude.json'),
+    JSON.stringify({
+      oauthAccount: {
+        accountUuid: 'claude-account-id',
+        emailAddress: 'reviewer@example.test',
+        displayName: 'Security Reviewer',
+      },
+      apiKey: 'must-not-be-copied',
+    })
+  );
+  await manager.finish(session, 0);
+
+  assert.equal(invocation.command, 'claude');
+  assert.deepEqual(invocation.args, ['auth', 'login', '--claudeai']);
+  assert.equal(invocation.options.env.CLAUDE_HOME, session.claudeLoginHome);
+  assert.equal(session.status, 'completed');
+  assert.equal(
+    JSON.parse(await readFile(join(session.claudeHome, '.credentials.json'), 'utf8')).claudeAiOauth.accessToken,
+    'new'
+  );
+  assert.deepEqual(JSON.parse(await readFile(join(session.claudeHome, '.open-kritt-account.json'), 'utf8')), {
+    provider: 'claude',
+    accountId: 'claude-account-id',
+    email: 'reviewer@example.test',
+    name: 'Security Reviewer',
+    organization: null,
+  });
+  assert.equal(
+    (await readFile(join(session.claudeHome, '.open-kritt-account.json'), 'utf8')).includes('must-not-be-copied'),
+    false
+  );
+  assert.match(
+    await readFile(runtimeConfigPath, 'utf8'),
+    new RegExp(`^ENGINE_CLAUDE_HOME=${session.claudeRuntimeHome}$`, 'm')
+  );
+  assert.equal((await readdir(claudeAccountsRoot)).length, 1);
+});
+
+test('managed Claude account removal deletes only the selected home and runtime entry', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'open-kritt-login-remove-managed-claude-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const accountsRoot = join(directory, 'claude-accounts');
+  const reviewerHome = join(accountsRoot, 'reviewer', '.claude');
+  const otherHome = join(accountsRoot, 'other', '.claude');
+  const runtimeConfigPath = join(directory, 'engine-runtime.env');
+  await mkdir(reviewerHome, { recursive: true });
+  await mkdir(otherHome, { recursive: true });
+  await writeFile(join(reviewerHome, '.credentials.json'), '{"claudeAiOauth":{"accessToken":"reviewer"}}');
+  await writeFile(join(otherHome, '.credentials.json'), '{"claudeAiOauth":{"accessToken":"other"}}');
+  await writeFile(
+    runtimeConfigPath,
+    'ENGINE_CLAUDE_HOME=/runtime-accounts/reviewer/.claude,/runtime-accounts/other/.claude\n'
+  );
+  const manager = new AccountLoginManager({
+    claudeAccountsRoot: accountsRoot,
+    claudeRuntimeAccountsRoot: '/runtime-accounts',
+    runtimeConfigPath,
+  });
+
+  assert.deepEqual(await manager.removeAccount('claude', 'reviewer'), {
+    provider: 'claude',
+    accountId: 'reviewer',
+    removed: true,
+  });
+  await assert.rejects(stat(join(accountsRoot, 'reviewer')), { code: 'ENOENT' });
+  assert.equal((await stat(otherHome)).isDirectory(), true);
+  assert.match(await readFile(runtimeConfigPath, 'utf8'), /^ENGINE_CLAUDE_HOME=\/runtime-accounts\/other\/\.claude$/m);
 });
 
 test('completed Claude login atomically promotes private OAuth credentials', async (t) => {

--- a/backend/test/accounts.test.js
+++ b/backend/test/accounts.test.js
@@ -142,6 +142,57 @@ test('Claude account refresh preserves sign-in status when credential renewal fa
   assert.equal(provider.accounts[0].statusKind, 'expired');
 });
 
+test('Claude account refresh renews each rejected managed account in its own home', async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  let requestCount = 0;
+  globalThis.fetch = async () => {
+    requestCount += 1;
+    return {
+      ok: true,
+      async json() {
+        return {
+          kind: 'claude',
+          accounts:
+            requestCount === 1
+              ? [
+                  { id: 'reviewer', statusKind: 'expired' },
+                  { id: 'researcher', statusKind: 'expired' },
+                ]
+              : [
+                  { id: 'reviewer', statusKind: 'available' },
+                  { id: 'researcher', statusKind: 'available' },
+                ],
+        };
+      },
+    };
+  };
+  const renewals = [];
+
+  const provider = await fetchExecutorProvider('claude', {
+    refresh: true,
+    executorViewUrl: 'http://executor-view:8090',
+    internalToken: 'backend-only-token',
+    claudeAccountsRoot: '/provider-homes/claude-accounts',
+    renewClaudeLogin: async (home) => {
+      renewals.push(home);
+      return true;
+    },
+  });
+
+  assert.equal(requestCount, 2);
+  assert.deepEqual(renewals, [
+    '/provider-homes/claude-accounts/reviewer/.claude',
+    '/provider-homes/claude-accounts/researcher/.claude',
+  ]);
+  assert.deepEqual(
+    provider.accounts.map((account) => account.statusKind),
+    ['available', 'available']
+  );
+});
+
 test('executor account integration fails closed when its internal token is unavailable', async (t) => {
   const originalFetch = globalThis.fetch;
   t.after(() => {

--- a/backend/test/dataIntegrity.test.js
+++ b/backend/test/dataIntegrity.test.js
@@ -229,6 +229,31 @@ test('runtime scan updates validate the complete prospective model selection', a
   assert.deepEqual(checkedSelection, { ...current, model: 'gpt-5.6' });
 });
 
+test('runtime scan updates validate a separate post-processing thinking effort', async () => {
+  const current = {
+    model: 'gpt-5.5',
+    modelProvider: 'codex',
+    harness: 'codex',
+    thinkingEffort: 'high',
+    configuration: { post_processing_thinking_effort: 'high' },
+  };
+  const checkedSelections = [];
+
+  const data = await validateScanRuntimeUpdate({ post_processing_thinking_effort: 'medium' }, current, {
+    assertAvailable: async (selection) => checkedSelections.push(selection),
+  });
+
+  assert.deepEqual(data, { postProcessingThinkingEffort: 'medium' });
+  assert.deepEqual(checkedSelections, [
+    {
+      model: 'gpt-5.5',
+      modelProvider: 'codex',
+      harness: 'codex',
+      thinkingEffort: 'medium',
+    },
+  ]);
+});
+
 test('runtime scan updates validate and replace depth model overrides', async () => {
   const current = {
     model: 'gpt-5.5',

--- a/backend/test/providerCredentials.test.js
+++ b/backend/test/providerCredentials.test.js
@@ -156,6 +156,32 @@ test('Codex homes left on disk but removed from the runtime registry stay inacti
   assert.equal(codex.configured, false);
 });
 
+test('provider status recognizes managed Claude homes in the runtime registry', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'open-kritt-provider-claude-accounts-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const accountsRoot = join(directory, 'claude-accounts');
+  const accountHome = join(accountsRoot, 'reviewer', '.claude');
+  const runtimeConfigPath = join(directory, 'engine-runtime.env');
+  await mkdir(accountHome, { recursive: true });
+  await writeFile(join(accountHome, '.credentials.json'), '{"claudeAiOauth":{"accessToken":"x"}}');
+  await writeFile(runtimeConfigPath, 'ENGINE_CLAUDE_HOME=/claude-accounts/reviewer/.claude\n');
+
+  const claude = providerCredentialStatuses({
+    env: {},
+    credentialsPath: join(directory, 'missing.json'),
+    loginOptions: {
+      claude: {
+        home: join(directory, 'unused-primary'),
+        accountsRoot,
+        runtimeConfigPath,
+      },
+    },
+  }).find((provider) => provider.id === 'claude');
+
+  assert.equal(claude.configured, true);
+  assert.equal(claude.source, 'claude_login');
+});
+
 test('account overview merges executor detail without exposing unrecognized fields', () => {
   const statuses = providerCredentialStatuses({
     env: { OPEN_KRITT_OPENROUTER_API_KEY_CONFIGURED: '1' },

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -171,6 +171,38 @@ test('model selection rejects non-string CLI arguments instead of coercing them'
   }
 });
 
+test('validateScan keeps post-processing thinking effort separate from workflow effort', () => {
+  const base = {
+    workflowId: '1',
+    postScriptId: '1',
+    repo_kind: 'remote',
+    repo_full: 'https://github.com/org/repo',
+    commit_sha: 'HEAD',
+    model: 'test-model',
+    model_provider: 'codex',
+    harness: 'codex',
+    thinking_effort: 'high',
+    severity_ranker: 'Rank by impact.',
+  };
+
+  const valid = validateScan({ ...base, post_processing_thinking_effort: 'medium' });
+
+  assert.equal(valid.thinkingEffort, 'high');
+  assert.equal(valid.postProcessingThinkingEffort, 'medium');
+  assert.equal(validateScan(base).postProcessingThinkingEffort, 'high');
+  assert.throws(
+    () =>
+      validateScan({
+        ...base,
+        model_provider: 'claude',
+        harness: 'claude-code',
+        post_processing_thinking_effort: 'ultra',
+      }),
+    (error) =>
+      error instanceof ValidationError && error.errors.some((item) => item.field === 'post_processing_thinking_effort')
+  );
+});
+
 test('depth model overrides normalize complete tuples and enforce workflow depths', () => {
   assert.deepEqual(
     validateModelOverrides(

--- a/database/init/026_refresh_patched_since_main.sql
+++ b/database/init/026_refresh_patched_since_main.sql
@@ -1,0 +1,38 @@
+-- Require the bundled Patched since script to verify the live main/default
+-- branch of the repository that owns each finding. Preserve customized scripts
+-- by updating only the exact prior bundled fingerprint.
+
+UPDATE public.post_scripts
+SET
+    description = 'Checks whether the reported risky behavior is fixed on the live main/default branch of the repository that owns the finding.',
+    content = $script$
+You are verifying whether a previously reported security finding is patched on the live main branch of the repository that owns the finding.
+
+The workspace is intentionally pinned to the scan commit. You can run shell and Git commands inside this disposable job container. The finding may belong to the primary repository or to a dependency repository; use the owning repository path supplied by the Open-Kritt patch-history instructions.
+
+Repository: {{repo_full}}
+Scan commit field: {{commit_sha}}
+Scan configuration JSON: {{configuration}}
+
+Reported finding:
+- Vulnerability type: {{vulnerability_type}}
+- Summary: {{summary}}
+- Explanation: {{explanation}}
+- Trigger flow: {{trigger_flow}}
+- Malicious input example: {{malicious_input_example}}
+- File path: {{file_path}}
+- Line: {{line}}
+
+Task:
+1. Confirm the vulnerable scan commit, but do not use the pinned checkout alone as evidence of current patch status.
+2. In the repository that owns the finding, fetch and compare the live origin/main branch without checking it out. If that repository genuinely has no main branch, fetch and compare its remote default branch and explicitly name that branch.
+3. Inspect the finding's exact code path on the fetched branch. Determine whether the risky behavior is fixed, still present, or ambiguous.
+4. If patched, identify the exact fixing commit when history permits. If Git/network access or comparison evidence is insufficient, set needs_manual_review=true and explain the failure. Do not report an unavailable comparison as unpatched.
+
+Return a concrete judgment tied to this finding and the live branch comparison, not a generic repository-health statement.
+$script$,
+    updated_at = now()
+WHERE name = 'Patched since'
+  AND description = 'Checks whether the reported risky behavior appears fixed or still present in the checked-out repository and scan context commits.'
+  AND md5(content) = '354172106e89761a35baaf9eae2268db'
+  AND output_format = '{"_chip_patched":"boolean","needs_manual_review":"boolean","confidence":"number","summary_result":"string","reasoning":"string","found_at_commit":"string","target_commit":"string"}';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       OPEN_KRITT_CODEX_RUNTIME_ACCOUNTS_DIR: /codex-accounts
       OPEN_KRITT_CODEX_INITIAL_HOME: ${ENGINE_CODEX_HOME:-/root/.codex}
       OPEN_KRITT_CLAUDE_HOME: /provider-homes/claude
+      OPEN_KRITT_CLAUDE_ACCOUNTS_DIR: /provider-homes/claude-accounts
+      OPEN_KRITT_CLAUDE_RUNTIME_ACCOUNTS_DIR: /claude-accounts
       OPEN_KRITT_ENGINE_RUNTIME_CONFIG_PATH: /engine-data/engine-runtime.env
       OPEN_KRITT_ENV_FILE_PATH: /project-config/.env
       EXECUTOR_VIEW_URL: http://executor-view:8090
@@ -65,7 +67,8 @@ services:
       # official Codex/Claude login commands. The engine keeps its own mounts.
       - ${ENGINE_CODEX_HOME_HOST:-./.data/codex}:/provider-homes/codex:z
       - ${ENGINE_CODEX_ACCOUNTS_HOST:-./.data/codex-accounts}:/provider-homes/codex-accounts:z
-      - ${ENGINE_CLAUDE_HOME:-./.data/claude}:/provider-homes/claude
+      - ${ENGINE_CLAUDE_HOME_HOST:-${ENGINE_CLAUDE_HOME:-./.data/claude}}:/provider-homes/claude
+      - ${ENGINE_CLAUDE_ACCOUNTS_HOST:-./.data/claude-accounts}:/provider-homes/claude-accounts
       - ${ENGINE_DATA_DIR_HOST:-./.data/engine}:/engine-data
       # Accounts mirrors durable provider/account configuration back to the
       # project environment file while secrets remain absent from API responses.
@@ -103,6 +106,7 @@ services:
       EXECUTOR_VIEW_URL: http://executor-view:8090
       EXECUTOR_VIEW_INTERNAL_TOKEN_FILE: /executor-auth/internal-token
       ENGINE_WORKSPACE_SETUP_CONCURRENCY: ${ENGINE_WORKSPACE_SETUP_CONCURRENCY:-2}
+      ENGINE_POST_PROCESS_WORKSPACE_MODE: ${ENGINE_POST_PROCESS_WORKSPACE_MODE:-copy}
       ENGINE_RETRY_COUNT: ${ENGINE_RETRY_COUNT:-2}
       ENGINE_HARNESS_TIMEOUT_SECONDS: ${ENGINE_HARNESS_TIMEOUT_SECONDS:-7200}
       ENGINE_MODEL_CATALOG_REFRESH_SECONDS: ${ENGINE_MODEL_CATALOG_REFRESH_SECONDS:-300}
@@ -144,7 +148,8 @@ services:
       # Codex logins created by Accounts and ./kritt setup share this root.
       - ${ENGINE_CODEX_ACCOUNTS_HOST:-./.data/codex-accounts}:/run/open-kritt-secrets/codex-accounts:z
       - ${ENGINE_CODEX_HOME_SOURCE_HOST:-./.data/codex-home-source}:/run/open-kritt-secrets/codex-home-source:ro,z
-      - ${ENGINE_CLAUDE_HOME:-./.data/claude}:/root/.claude
+      - ${ENGINE_CLAUDE_HOME_HOST:-${ENGINE_CLAUDE_HOME:-./.data/claude}}:/root/.claude
+      - ${ENGINE_CLAUDE_ACCOUNTS_HOST:-./.data/claude-accounts}:/run/open-kritt-secrets/claude-accounts:z
       - ${EXECUTOR_VIEW_AUTH_HOST:-./.data/engine/executor-auth}:/executor-auth:ro
       - /var/run/docker.sock:/var/run/docker.sock
       # Local repositories are copied into scan-specific snapshots; the host source
@@ -172,6 +177,7 @@ services:
       EXECUTOR_VIEW_SECURE_COOKIE: ${EXECUTOR_VIEW_SECURE_COOKIE:-false}
       EXECUTOR_VIEW_CODEX_HOME: ${ENGINE_CODEX_HOME:-/root/.codex}
       EXECUTOR_VIEW_CLAUDE_HOME: /root/.claude
+      EXECUTOR_VIEW_CLAUDE_ACCOUNTS_ROOT: /claude-accounts
       EXECUTOR_VIEW_ENGINE_DATA_DIR: /data
       EXECUTOR_VIEW_ENGINE_RUNTIME_CONFIG_PATH: ${ENGINE_RUNTIME_CONFIG_PATH:-/data/engine-runtime.env}
       OPEN_KRITT_PROVIDER_CREDENTIALS_PATH: /credentials/providers.json
@@ -188,7 +194,8 @@ services:
       - ${ENGINE_CODEX_HOME_HOST:-./.data/codex}:/root/.codex:ro,z
       - ${ENGINE_CODEX_ACCOUNTS_HOST:-./.data/codex-accounts}:/codex-accounts:ro,z
       - ${ENGINE_CODEX_HOME_SOURCE_HOST:-./.data/codex-home-source}:/codex-home-source:ro,z
-      - ${ENGINE_CLAUDE_HOME:-./.data/claude}:/root/.claude:ro
+      - ${ENGINE_CLAUDE_HOME_HOST:-${ENGINE_CLAUDE_HOME:-./.data/claude}}:/root/.claude:ro
+      - ${ENGINE_CLAUDE_ACCOUNTS_HOST:-./.data/claude-accounts}:/claude-accounts:ro,z
       - ${EXECUTOR_VIEW_AUTH_HOST:-./.data/engine/executor-auth}:/executor-auth
     healthcheck:
       test:

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /run/open-kritt-secrets \
     && chmod 0700 /run/open-kritt-secrets \
     && ln -s /run/open-kritt-secrets/credentials /credentials \
     && ln -s /run/open-kritt-secrets/codex-accounts /codex-accounts \
+    && ln -s /run/open-kritt-secrets/claude-accounts /claude-accounts \
     && ln -s /run/open-kritt-secrets/codex-home-source /codex-home-source \
     && ln -s /run/open-kritt-secrets/local-repos /local_repos
 

--- a/engine/open_kritt_engine/db.py
+++ b/engine/open_kritt_engine/db.py
@@ -903,7 +903,13 @@ class Database:
         post_script_name: str | None = None,
         vulnerability_id: int | None = None,
     ) -> int | None:
-        lock_key = f"post-process:{scan_id}:{kind}:{batch_index or 0}:{post_script_id or 0}:{vulnerability_id or 0}"
+        # Batch indexes are chosen before this transaction. Lock batch pipelines by
+        # logical kind so two workers cannot turn the same snapshot into different
+        # batch indexes; post-script jobs remain independently claimable.
+        if kind == "post_script":
+            lock_key = f"post-process:{scan_id}:{kind}:{post_script_id or 0}:{vulnerability_id or 0}"
+        else:
+            lock_key = f"post-process:{scan_id}:{kind}"
         conn.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", (lock_key,))
         scan = conn.execute(
             """
@@ -932,20 +938,44 @@ class Database:
                 (scan_id, kind, vulnerability_id, post_script_id),
             ).fetchone()
         else:
+            # The scan row lock serializes this recheck with every other claim.
             existing = conn.execute(
                 """
                 SELECT id
                 FROM workflows.post_process_metadata
                 WHERE scan_id = %s
                   AND kind = %s
-                  AND batch_index = %s
-                  AND status IN ('running', 'completed')
+                  AND (
+                      status = 'running'
+                      OR (batch_index = %s AND status = 'completed')
+                  )
                 LIMIT 1
                 """,
                 (scan_id, kind, batch_index),
             ).fetchone()
         if existing:
             return None
+        expected_target_ids = sorted(set(target_vulnerability_ids))
+        if kind in {"dedupe", "ranker"}:
+            if not expected_target_ids:
+                return None
+            target_state = (
+                "dedupe_is_canonical IS NULL"
+                if kind == "dedupe"
+                else "dedupe_is_canonical = true AND bounty_rank IS NULL"
+            )
+            eligible = conn.execute(
+                f"""
+                SELECT count(*) AS count
+                FROM workflows.vulnerabilities
+                WHERE scan_id = %s
+                  AND id = ANY(%s::bigint[])
+                  AND {target_state}
+                """,
+                (scan_id, expected_target_ids),
+            ).fetchone()
+            if int(eligible["count"]) != len(expected_target_ids):
+                return None
         previous = conn.execute(
             """
             SELECT id

--- a/engine/open_kritt_engine/harnesses.py
+++ b/engine/open_kritt_engine/harnesses.py
@@ -786,7 +786,13 @@ def _container_path(value: str, *, repo_dir: str, home: str) -> str:
     return value
 
 
-def _scan_docker_command(cmd: list[str], repo_dir: str, env: dict[str, str]) -> list[str]:
+def _scan_docker_command(
+    cmd: list[str],
+    repo_dir: str,
+    env: dict[str, str],
+    *,
+    runner_image: str | None = None,
+) -> list[str]:
     """Run a tool-enabled harness in a per-job network and mount namespace."""
 
     docker = shutil.which(os.getenv("ENGINE_DOCKER_BIN", "docker"))
@@ -799,9 +805,9 @@ def _scan_docker_command(cmd: list[str], repo_dir: str, env: dict[str, str]) -> 
     if not home:
         raise HarnessError("Isolated scan runner requires HOME in the job environment", code="configuration_error")
 
-    workspace_host = _host_path_for_engine_data_path(repo_dir)
     home_host = _host_path_for_engine_data_path(home)
-    image = os.getenv("ENGINE_SCAN_RUNNER_IMAGE", "open-kritt-engine:local")
+    workspace_host = None if runner_image else _host_path_for_engine_data_path(repo_dir)
+    image = runner_image or os.getenv("ENGINE_SCAN_RUNNER_IMAGE", "open-kritt-engine:local")
     user = "0:0"
     container_name = _docker_container_name(repo_dir)
     network = f"{SCAN_SANDBOX_NETWORK_PREFIX}{container_name.removeprefix('open-kritt-scan-')}"[:63].rstrip("-.")
@@ -837,8 +843,6 @@ def _scan_docker_command(cmd: list[str], repo_dir: str, env: dict[str, str]) -> 
         "NODE_EXTRA_CA_CERTS",
     ]
 
-    workspace_mount = f"type=bind,src={workspace_host},dst={CLAUDE_RUNNER_WORKDIR}"
-
     docker_cmd = [
         docker,
         "run",
@@ -859,13 +863,22 @@ def _scan_docker_command(cmd: list[str], repo_dir: str, env: dict[str, str]) -> 
         CLAUDE_RUNNER_WORKDIR,
         "--pids-limit",
         "512",
-        "--mount",
-        workspace_mount,
-        "--mount",
-        f"type=bind,src={home_host},dst={CLAUDE_RUNNER_HOME}",
-        "--tmpfs",
-        "/tmp:rw,nosuid,nodev,size=1g",
     ]
+    if workspace_host is not None:
+        docker_cmd.extend(
+            [
+                "--mount",
+                f"type=bind,src={workspace_host},dst={CLAUDE_RUNNER_WORKDIR}",
+            ]
+        )
+    docker_cmd.extend(
+        [
+            "--mount",
+            f"type=bind,src={home_host},dst={CLAUDE_RUNNER_HOME}",
+            "--tmpfs",
+            "/tmp:rw,nosuid,nodev,size=1g",
+        ]
+    )
     for key, value in container_env.items():
         docker_cmd.extend(["--env", f"{key}={value}"])
     for key in inherited_env:
@@ -1418,10 +1431,11 @@ class CodexHarness:
         thinking_effort: str | None = None,
         env: dict[str, str] | None = None,
         allow_tools: bool = True,
+        runner_image: str | None = None,
     ) -> HarnessResult:
         usage = self.cli_gate.use() if self.cli_gate is not None else nullcontext()
         with usage:
-            return self._run(prompt, schema, repo_dir, model, thinking_effort, env, allow_tools)
+            return self._run(prompt, schema, repo_dir, model, thinking_effort, env, allow_tools, runner_image)
 
     def _run(
         self,
@@ -1432,6 +1446,7 @@ class CodexHarness:
         thinking_effort: str | None,
         env: dict[str, str] | None,
         allow_tools: bool,
+        runner_image: str | None,
     ) -> HarnessResult:
         actual_env = env if env is not None else _base_env()
         temp_parent = actual_env.get("HOME")
@@ -1455,7 +1470,11 @@ class CodexHarness:
                 max_subagents=self.max_subagents if allow_tools else None,
             )
             if allow_tools:
-                cmd = _scan_docker_command(cmd, repo_dir, actual_env)
+                cmd = (
+                    _scan_docker_command(cmd, repo_dir, actual_env, runner_image=runner_image)
+                    if runner_image
+                    else _scan_docker_command(cmd, repo_dir, actual_env)
+                )
             started_at = time.time()
             proc = _run_process(cmd, prompt, repo_dir, self.timeout_seconds, env=actual_env)
             output_files = {}
@@ -1493,6 +1512,7 @@ class CodexHarness:
                             model=model,
                             thinking_effort=thinking_effort,
                             env=actual_env,
+                            runner_image=runner_image,
                         )
                         parsed_payload = resume_result.payload
                         usage = resume_result.usage or usage
@@ -1540,6 +1560,7 @@ class CodexHarness:
         model: str,
         thinking_effort: str | None,
         env: dict[str, str],
+        runner_image: str | None = None,
     ) -> HarnessResult:
         cmd = [
             "codex",
@@ -1564,7 +1585,11 @@ class CodexHarness:
         if thinking_effort and thinking_effort != "default":
             cmd.extend(["-c", f'model_reasoning_effort="{thinking_effort}"'])
         cmd.extend([session_id, "-"])
-        cmd = _scan_docker_command(cmd, repo_dir, env)
+        cmd = (
+            _scan_docker_command(cmd, repo_dir, env, runner_image=runner_image)
+            if runner_image
+            else _scan_docker_command(cmd, repo_dir, env)
+        )
         started_at = time.time()
         proc = _run_process(cmd, _resume_json_prompt(schema), repo_dir, self.timeout_seconds, env=env)
         output_files = {}
@@ -1623,6 +1648,7 @@ class ClaudeHarness:
         thinking_effort: str | None = None,
         env: dict[str, str] | None = None,
         allow_tools: bool = True,
+        runner_image: str | None = None,
     ) -> HarnessResult:
         base_env = env if env is not None else _base_env()
         provider = claude_model_provider(model, base_env, self.model_provider)
@@ -1654,7 +1680,15 @@ class ClaudeHarness:
             cmd.extend(["--include-partial-messages", "--verbose"])
         if thinking_effort and thinking_effort != "default":
             cmd.extend(["--effort", thinking_effort])
-        run_cmd = _scan_docker_command(cmd, repo_dir, actual_env) if allow_tools else cmd
+        run_cmd = (
+            (
+                _scan_docker_command(cmd, repo_dir, actual_env, runner_image=runner_image)
+                if runner_image
+                else _scan_docker_command(cmd, repo_dir, actual_env)
+            )
+            if allow_tools
+            else cmd
+        )
         timeout_seconds = self.timeout_seconds
         if provider != "openrouter":
             timeout_seconds = claude_oauth_timeout_seconds(
@@ -1749,6 +1783,7 @@ class CursorHarness:
         thinking_effort: str | None = None,
         env: dict[str, str] | None = None,
         allow_tools: bool = True,
+        runner_image: str | None = None,
     ) -> HarnessResult:
         if not allow_tools:
             raise HarnessError(
@@ -1774,7 +1809,11 @@ class CursorHarness:
             repo_dir,
             "Read the full task from standard input, complete it in this workspace, and return only the requested structured JSON.",
         ]
-        cmd = _scan_docker_command(cmd, repo_dir, actual_env)
+        cmd = (
+            _scan_docker_command(cmd, repo_dir, actual_env, runner_image=runner_image)
+            if runner_image
+            else _scan_docker_command(cmd, repo_dir, actual_env)
+        )
         proc = _run_process(cmd, prompt, repo_dir, self.timeout_seconds, env=actual_env)
         process_output = _process_output(proc)
         try:

--- a/engine/open_kritt_engine/models.py
+++ b/engine/open_kritt_engine/models.py
@@ -52,6 +52,19 @@ def model_selection_for_depth(scan: dict[str, Any], depth: int | None = None) ->
     )
 
 
+def post_processing_thinking_effort(scan: dict[str, Any]) -> str:
+    configuration = scan.get("configuration")
+    if not isinstance(configuration, dict):
+        configuration = {}
+    fallback = _selection_value(scan, "thinking_effort", "thinkingEffort", "medium")
+    return _selection_value(
+        configuration,
+        "post_processing_thinking_effort",
+        "postProcessingThinkingEffort",
+        fallback,
+    )
+
+
 @dataclass(frozen=True)
 class Step:
     id: int

--- a/engine/open_kritt_engine/post_processing.py
+++ b/engine/open_kritt_engine/post_processing.py
@@ -14,6 +14,7 @@ from .harnesses import (
     scan_model_provider,
 )
 from .model_output_artifacts import record_model_error_output
+from .models import post_processing_thinking_effort
 from .prompting import (
     append_schema_prompt,
     harness_prompt,
@@ -29,6 +30,7 @@ from .schema import EXTRACTOR_HELPER_FIELD, OutputValidationError, output_schema
 from .workspace import (
     cleanup_job_workspace,
     cleanup_workspace,
+    image_workspace_enabled,
     mark_provider_account_available,
     mark_provider_account_rate_limited,
     prepare_dependency_workspace,
@@ -433,9 +435,10 @@ def configured_post_script_ids(scan: dict[str, Any]) -> list[int]:
 
 
 class PostProcessor:
-    def __init__(self, config, db):
+    def __init__(self, config, db, *, workspace_setup_slots=None):
         self.config = config
         self.db = db
+        self.workspace_setup_slots = workspace_setup_slots
 
     def process_once(self, scan: dict[str, Any], harness) -> bool:
         scan_id = _int(scan["id"])
@@ -453,10 +456,19 @@ class PostProcessor:
         if any(row.get("dedupe_is_canonical") is None for row in vulnerabilities):
             return self._run_next_dedupe_batch(scan, harness)
 
-        if any(row.get("dedupe_is_canonical") is True and row.get("bounty_rank") is None for row in vulnerabilities):
-            return self._run_next_ranker_batch(scan, harness)
+        ranking_pending = any(
+            row.get("dedupe_is_canonical") is True and row.get("bounty_rank") is None for row in vulnerabilities
+        )
+        if ranking_pending and self._run_next_ranker_batch(scan, harness):
+            return True
 
-        return self._run_next_post_script_or_complete(scan, harness)
+        # A different worker owns the serialized ranker. This worker can still
+        # enrich findings because post scripts do not participate in rank ordering.
+        return self._run_next_post_script_or_complete(
+            scan,
+            harness,
+            allow_complete=not ranking_pending,
+        )
 
     def _agent_skills(self, scan: dict[str, Any]) -> list[dict[str, Any]]:
         if not hasattr(self.db, "load_agent_skills"):
@@ -479,16 +491,23 @@ class PostProcessor:
     def _prepare_workspace(
         self, metadata_id: int, scan: dict[str, Any], agent_skills: list[dict[str, Any]] | None = None
     ):
-        return prepare_dependency_workspace(
-            data_dir=self.config.data_dir,
-            checkout_cache_dir=getattr(self.config, "checkout_cache_dir", None),
-            metadata_id=POST_WORKSPACE_ID_OFFSET + metadata_id,
-            scan=scan,
-            github_token=self.config.github_token,
-            agent_skills=agent_skills or [],
-            harness_name=normalize_harness_name(scan["harness"]),
-            model_provider=self._model_provider(scan),
-        )
+        def prepare():
+            return prepare_dependency_workspace(
+                data_dir=self.config.data_dir,
+                checkout_cache_dir=getattr(self.config, "checkout_cache_dir", None),
+                metadata_id=POST_WORKSPACE_ID_OFFSET + metadata_id,
+                scan=scan,
+                github_token=self.config.github_token,
+                agent_skills=agent_skills or [],
+                harness_name=normalize_harness_name(scan["harness"]),
+                model_provider=self._model_provider(scan),
+                use_snapshot_image=image_workspace_enabled(data_dir=getattr(self.config, "data_dir", None)),
+            )
+
+        if self.workspace_setup_slots is None:
+            return prepare()
+        with self.workspace_setup_slots:
+            return prepare()
 
     def _run_harness_with_retries(
         self,
@@ -513,10 +532,11 @@ class PostProcessor:
                 context = {**(prompt_context or {}), **workspace_context(prepared)}
                 if "{{patched_since_history}}" in prompt_template:
                     context["patched_since_history"] = patched_since_workspace_history_context(
-                        prepared.repo_dir,
+                        getattr(prepared, "source_repo_dir", None) or prepared.repo_dir,
                         prepared.manifest,
                         scan,
                         context.get("file_path"),
+                        github_token=getattr(self.config, "github_token", None),
                     )
                 rendered = render_prompt(prompt_template, context)
                 prompt_body = harness_prompt(rendered, multi_output=multi_output, schema=schema)
@@ -528,7 +548,7 @@ class PostProcessor:
                 prompt_body,
             ]
             final_prompt = "\n\n".join(part for part in prompt_parts if part)
-            thinking_effort = scan.get("thinking_effort") or "medium"
+            thinking_effort = post_processing_thinking_effort(scan)
             with self.db.connect() as conn:
                 self.db.update_post_process_metadata(
                     conn,
@@ -541,8 +561,8 @@ class PostProcessor:
                     prompt_filled=final_prompt,
                     phase="running_harness",
                     codex_source_home=getattr(prepared.workspace, "codex_source_home", None),
-                    codex_account_id=getattr(prepared.workspace, "codex_account_id", None),
-                    codex_account_email=getattr(prepared.workspace, "codex_account_email", None),
+                    codex_account_id=getattr(prepared.workspace, "provider_account_id", None),
+                    codex_account_email=getattr(prepared.workspace, "provider_account_email", None),
                 )
                 conn.commit()
 
@@ -560,13 +580,19 @@ class PostProcessor:
                         getattr(prepared.workspace, "provider_account_home", None),
                         data_dir=getattr(self.config, "data_dir", None),
                     ):
+                        harness_arguments = {
+                            "prompt": final_prompt,
+                            "schema": schema,
+                            "repo_dir": prepared.repo_dir,
+                            "model": scan["model"],
+                            "thinking_effort": thinking_effort,
+                            "env": prepared.workspace.env,
+                        }
+                        runner_image = getattr(prepared, "runner_image", None)
+                        if runner_image:
+                            harness_arguments["runner_image"] = runner_image
                         result = harness.run(
-                            prompt=final_prompt,
-                            schema=schema,
-                            repo_dir=prepared.repo_dir,
-                            model=scan["model"],
-                            thinking_effort=thinking_effort,
-                            env=prepared.workspace.env,
+                            **harness_arguments,
                         )
                     mark_provider_account_available(
                         getattr(prepared.workspace, "provider_account_provider", None),
@@ -623,8 +649,8 @@ class PostProcessor:
                             codex_session_id=codex_session_id,
                             phase="running_harness",
                             codex_source_home=getattr(prepared.workspace, "codex_source_home", None),
-                            codex_account_id=getattr(prepared.workspace, "codex_account_id", None),
-                            codex_account_email=getattr(prepared.workspace, "codex_account_email", None),
+                            codex_account_id=getattr(prepared.workspace, "provider_account_id", None),
+                            codex_account_email=getattr(prepared.workspace, "provider_account_email", None),
                         )
                         conn.commit()
                     if isinstance(exc, HarnessError) and (
@@ -698,7 +724,7 @@ class PostProcessor:
                 prompt_filled="",
                 model=current["model"],
                 harness=current["harness"],
-                thinking_effort=current.get("thinking_effort"),
+                thinking_effort=post_processing_thinking_effort(current),
                 model_provider=self._model_provider(current),
                 run_started_at=started,
             )
@@ -786,7 +812,7 @@ class PostProcessor:
                 prompt_filled="",
                 model=current["model"],
                 harness=current["harness"],
-                thinking_effort=current.get("thinking_effort"),
+                thinking_effort=post_processing_thinking_effort(current),
                 model_provider=self._model_provider(current),
                 run_started_at=started,
             )
@@ -848,17 +874,29 @@ class PostProcessor:
                 conn.commit()
             raise
 
-    def _run_next_post_script_or_complete(self, scan: dict[str, Any], harness) -> bool:
+    def _run_next_post_script_or_complete(
+        self,
+        scan: dict[str, Any],
+        harness,
+        *,
+        allow_complete: bool = True,
+    ) -> bool:
         scan_id = _int(scan["id"])
         with self.db.connect() as conn:
             current = self.db.load_scan(conn, scan_id)
             if not current or current["status"] != "post_processing":
                 return False
-            post_script_ids = configured_post_script_ids(current)
-            if not post_script_ids:
+
+            def complete_if_ready() -> bool:
+                if not allow_complete or self.db.count_running_post_process(conn, scan_id, "ranker"):
+                    return False
                 self.db.set_scan_status_if_current(conn, scan_id, "post_processing", "completed")
                 conn.commit()
                 return True
+
+            post_script_ids = configured_post_script_ids(current)
+            if not post_script_ids:
+                return complete_if_ready()
             rows = conn.execute(
                 "SELECT * FROM public.post_scripts WHERE id = ANY(%s::bigint[])",
                 (post_script_ids,),
@@ -868,9 +906,7 @@ class PostProcessor:
                 scripts_by_id[post_script_id] for post_script_id in post_script_ids if post_script_id in scripts_by_id
             ]
             if not post_scripts:
-                self.db.set_scan_status_if_current(conn, scan_id, "post_processing", "completed")
-                conn.commit()
-                return True
+                return complete_if_ready()
             post_script = None
             row = None
             for candidate_script in post_scripts:
@@ -907,9 +943,7 @@ class PostProcessor:
             if not post_script or not row:
                 if self.db.count_running_post_process(conn, scan_id, "post_script"):
                     return False
-                self.db.set_scan_status_if_current(conn, scan_id, "post_processing", "completed")
-                conn.commit()
-                return True
+                return complete_if_ready()
             prompt_template = post_script["content"]
             if str(post_script.get("name") or "").strip().casefold() == "patched since":
                 prompt_template = patched_since_prompt(prompt_template)
@@ -928,7 +962,7 @@ class PostProcessor:
                 prompt_filled="",
                 model=current["model"],
                 harness=current["harness"],
-                thinking_effort=current.get("thinking_effort"),
+                thinking_effort=post_processing_thinking_effort(current),
                 model_provider=self._model_provider(current),
                 run_started_at=started,
             )

--- a/engine/open_kritt_engine/prompting.py
+++ b/engine/open_kritt_engine/prompting.py
@@ -1,6 +1,7 @@
 import fcntl
 import hashlib
 import json
+import logging
 import os
 import re
 import subprocess
@@ -8,9 +9,10 @@ import threading
 from pathlib import Path
 from typing import Any
 
-from .repository import LOCAL_SNAPSHOT_REVISION
+from .repository import LOCAL_SNAPSHOT_REVISION, fetch_remote_ref
 from .schema import EXTRACTOR_HELPER_FIELD
 
+LOGGER = logging.getLogger("open_kritt_engine.prompting")
 REF_RE = re.compile(r"\{\{\s*([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\s*\}\}")
 SELECTED_AGENT_SKILLS_SLUG = "open-kritt-selected-skills"
 PATCH_HISTORY_REFS = (
@@ -18,9 +20,10 @@ PATCH_HISTORY_REFS = (
     "refs/remotes/origin",
     "refs/remotes/open-kritt-patched-since",
 )
-PATCH_HISTORY_CONTEXT_VERSION = 2
+PATCH_HISTORY_CONTEXT_VERSION = 3
 PATCH_HISTORY_DEFAULT_REF = "refs/remotes/open-kritt-patched-since/default"
 PATCH_HISTORY_DIFF_LIMIT = 24_000
+PATCH_HISTORY_FETCH_TIMEOUT = 120
 _PATCH_HISTORY_LOCKS: dict[str, threading.Lock] = {}
 _PATCH_HISTORY_LOCKS_GUARD = threading.Lock()
 
@@ -94,12 +97,23 @@ def scan_revision(scan: dict[str, Any]) -> str:
 def patched_since_prompt(template: str) -> str:
     return f"""Open-Kritt patch-history comparison (authoritative instructions):
 The worktree intentionally remains checked out at the scan's pinned, potentially vulnerable commit. Do not use
-`git rev-parse HEAD` or the checked-out files alone as evidence that the finding is still unpatched. The engine has
-selected the repository that owns the finding path, fetched its remote default branch, and precomputed path-scoped
-comparison evidence below. Treat `current_default` as a successful identity comparison: the pinned commit and current
-remote default are the same commit. For `available`, use the supplied diff and commit log to determine whether the
-finding changed. When a specific fixing commit is identifiable, use that commit rather than assuming the newest tree
-proves when or how the behavior changed. Do not claim to have run Git commands that are not available to you.
+`git rev-parse HEAD` or the checked-out files alone as evidence that the finding is still unpatched.
+
+On every run, independently check the live main branch of the repository that owns the finding, identified by
+`repository.workspace_path`. Use Git in this disposable container. Resolve and fetch `origin/main` into a temporary
+remote-tracking ref without checking it out. If that repository genuinely has no `main` branch, resolve `origin`'s
+symbolic HEAD, fetch that exact default branch instead, and state which branch was compared. Compare the vulnerable
+commit to the fetched commit, scoped to `finding_path.repo_relative`, and inspect the newer implementation directly.
+Keep the worktree pinned.
+
+The engine-provided context below is supporting path-scoped evidence, not a substitute for this live Git check. Treat
+`current_default` as a successful identity comparison: the pinned commit and current remote default are the same
+commit. For `available`, use the supplied diff and commit log together with your live verification. If the direct
+comparison fails, report the actual Git/network error and require manual review; never translate unavailable history
+into `patched: false`.
+
+When a specific fixing commit is identifiable, use that commit rather than assuming the newest tree proves when or how
+the behavior changed. Do not claim to have run Git commands that are not available to you.
 
 Set `found_at_commit` to the vulnerable scan commit. Set `target_commit` to the exact fixing commit when
 the patch-status boolean (`_chip_patched` or `patched`, whichever the output schema requests) is true, or to the
@@ -118,7 +132,8 @@ def patched_since_history_context(
     scan: dict[str, Any],
     *,
     history_repo_dir: str | None = None,
-    fetch_timeout: int = 30,
+    fetch_timeout: int = PATCH_HISTORY_FETCH_TIMEOUT,
+    github_token: str | None = None,
 ) -> str:
     """Describe newer descendants while keeping network history shared per scan."""
     if (scan.get("repo_kind") or "remote") == "local":
@@ -165,6 +180,7 @@ def patched_since_history_context(
         target_revision=target_revision,
         target=target,
         fetch_timeout=fetch_timeout,
+        github_token=github_token,
     )
     if history_repo != repo_dir and not _install_patch_history_refs(history_repo, repo_dir):
         context = {
@@ -183,7 +199,8 @@ def patched_since_workspace_history_context(
     scan: dict[str, Any],
     finding_file_path: str | None,
     *,
-    fetch_timeout: int = 30,
+    fetch_timeout: int = PATCH_HISTORY_FETCH_TIMEOUT,
+    github_token: str | None = None,
 ) -> str:
     """Compare the finding's owning repository and exact path with its default branch."""
 
@@ -204,6 +221,7 @@ def patched_since_workspace_history_context(
             str(selected_repo_dir),
             selected_scan,
             fetch_timeout=fetch_timeout,
+            github_token=github_token,
         )
     )
     target = context.get("target_commit")
@@ -215,7 +233,8 @@ def patched_since_workspace_history_context(
         "kind": selected_scan["repo_kind"],
         "alias": selected.get("alias"),
         "role": "dependency" if selected.get("alias") else "primary",
-        "workspace_path": str(selected_repo_dir),
+        "workspace_path": selected.get("path")
+        or (f"/workspace/{selected.get('alias')}" if selected.get("alias") else "/workspace"),
     }
     context["finding_path"] = {
         "reported": finding_file_path or "",
@@ -250,6 +269,7 @@ def _cached_patch_history_context(
     target_revision: str,
     target: str,
     fetch_timeout: int,
+    github_token: str | None,
 ) -> dict[str, Any]:
     state_dir = Path(history_repo) / ".git" / "open-kritt-patched-since"
     if not state_dir.parent.is_dir():
@@ -258,6 +278,7 @@ def _cached_patch_history_context(
             target_revision=target_revision,
             target=target,
             fetch_timeout=fetch_timeout,
+            github_token=github_token,
         )
     state_dir.mkdir(parents=True, exist_ok=True)
     cache_key = hashlib.sha256(
@@ -280,7 +301,10 @@ def _cached_patch_history_context(
                 target_revision=target_revision,
                 target=target,
                 fetch_timeout=fetch_timeout,
+                github_token=github_token,
             )
+            if any(item.get("status") != "fetched" for item in context.get("fetch_results", [])):
+                return context
             tmp_marker = marker.with_suffix(".tmp")
             tmp_marker.write_text(json.dumps(context, sort_keys=True) + "\n", encoding="utf-8")
             os.replace(tmp_marker, marker)
@@ -293,11 +317,13 @@ def _build_patch_history_context(
     target_revision: str,
     target: str,
     fetch_timeout: int,
+    github_token: str | None,
 ) -> dict[str, Any]:
     fetch_status = _git_fetch_status(
         history_repo,
         f"+HEAD:{PATCH_HISTORY_DEFAULT_REF}",
         timeout=fetch_timeout,
+        github_token=github_token,
     )
     fetch_results = [
         {
@@ -546,20 +572,22 @@ def _patch_history_thread_lock(path: Path) -> threading.Lock:
         return lock
 
 
-def _git_fetch_status(repo_dir: str, refspec: str, *, timeout: int) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "fetch", "--quiet", "--prune", "--no-tags", "origin", refspec],
-            cwd=repo_dir,
-            text=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=timeout,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return "unavailable"
-    return "fetched" if result.returncode == 0 else "unavailable"
+def _git_fetch_status(
+    repo_dir: str,
+    refspec: str,
+    *,
+    timeout: int,
+    github_token: str | None = None,
+) -> str:
+    fetched, detail = fetch_remote_ref(
+        repo_dir,
+        refspec,
+        github_token=github_token,
+        timeout=timeout,
+    )
+    if not fetched:
+        LOGGER.warning("patch-history fetch failed for %s: %s", repo_dir, detail or "unknown Git error")
+    return "fetched" if fetched else "unavailable"
 
 
 def _git_stdout(repo_dir: str, *args: str) -> str:

--- a/engine/open_kritt_engine/repository.py
+++ b/engine/open_kritt_engine/repository.py
@@ -153,6 +153,38 @@ def resolve_remote_head(repo_full: str, github_token: str | None = None) -> str:
     return commit.lower()
 
 
+def fetch_remote_ref(
+    repo_dir: str,
+    refspec: str,
+    *,
+    github_token: str | None = None,
+    timeout: int = 120,
+) -> tuple[bool, str]:
+    """Fetch one remote ref using the checkout authentication policy."""
+
+    command = ["git", "fetch", "--quiet", "--prune", "--no-tags", "origin", refspec]
+    try:
+        with _github_auth_environment(github_token) as git_env:
+            actual_command = _authenticated_git_command(command, git_env)
+            result = subprocess.run(
+                actual_command,
+                cwd=repo_dir,
+                env=git_env,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=max(1, int(timeout)),
+            )
+    except subprocess.TimeoutExpired:
+        return False, f"fetch timed out after {max(1, int(timeout))} seconds"
+    except OSError as exc:
+        return False, str(exc)
+    if result.returncode == 0:
+        return True, ""
+    detail = _redact_git_secrets((result.stderr or result.stdout or "git fetch failed").strip(), git_env)
+    return False, detail[-2000:]
+
+
 def checkout_repo(repo_full: str, commit_sha: str, base_dir: str, github_token: str | None = None) -> tuple[str, str]:
     os.makedirs(base_dir, exist_ok=True)
     repo_dir = safe_repo_dir(base_dir, repo_full)

--- a/engine/open_kritt_engine/runtime_config.py
+++ b/engine/open_kritt_engine/runtime_config.py
@@ -14,6 +14,7 @@ RUNTIME_ENV_ALIASES = {
     "ENGINE_CODEX_HOME": ("ENGINE_CODEX_HOME", "CODEX_HOME"),
     "ENGINE_CLAUDE_HOME": ("ENGINE_CLAUDE_HOME", "CLAUDE_HOME"),
     "ENGINE_WORKSPACE_SETUP_CONCURRENCY": ("ENGINE_WORKSPACE_SETUP_CONCURRENCY",),
+    "ENGINE_POST_PROCESS_WORKSPACE_MODE": ("ENGINE_POST_PROCESS_WORKSPACE_MODE",),
     "ENGINE_RETRY_COUNT": ("ENGINE_RETRY_COUNT",),
     "ENGINE_HARNESS_TIMEOUT_SECONDS": ("ENGINE_HARNESS_TIMEOUT_SECONDS",),
 }
@@ -46,6 +47,7 @@ def ensure_runtime_config_file(data_dir: str | None = None) -> Path:
         "ENGINE_CODEX_HOME": os.getenv("ENGINE_CODEX_HOME") or os.getenv("CODEX_HOME") or "/root/.codex",
         "ENGINE_CLAUDE_HOME": os.getenv("ENGINE_CLAUDE_HOME") or os.getenv("CLAUDE_HOME") or "/root/.claude",
         "ENGINE_WORKSPACE_SETUP_CONCURRENCY": os.getenv("ENGINE_WORKSPACE_SETUP_CONCURRENCY") or "2",
+        "ENGINE_POST_PROCESS_WORKSPACE_MODE": os.getenv("ENGINE_POST_PROCESS_WORKSPACE_MODE") or "copy",
         "ENGINE_RETRY_COUNT": os.getenv("ENGINE_RETRY_COUNT") or "2",
         "ENGINE_HARNESS_TIMEOUT_SECONDS": os.getenv("ENGINE_HARNESS_TIMEOUT_SECONDS") or "7200",
     }
@@ -54,7 +56,7 @@ def ensure_runtime_config_file(data_dir: str | None = None) -> Path:
         "# open-kritt live engine runtime config",
         "# Edit this file while the engine is running to change future job pickup.",
         "# Explicit environment values are synced here once at each engine startup.",
-        "# Existing Codex calls keep their current account until they finish.",
+        "# Existing provider calls keep their current account until they finish.",
         "# ENGINE_WORKER_COUNT=0 pauses new job pickup without killing running jobs.",
         "# ENGINE_MAX_CONCURRENT_SCANS caps immediate scans; queued work waits for an empty active pool.",
         "# ENGINE_MAX_WORKERS_PER_SCAN=0 shares workers evenly; a positive value adds a hard per-scan cap.",
@@ -64,8 +66,9 @@ def ensure_runtime_config_file(data_dir: str | None = None) -> Path:
         "# ENGINE_MIN_FREE_STORAGE_GB pauses new scan containers below the configured free-space floor.",
         "# ENGINE_RETRY_COUNT and ENGINE_HARNESS_TIMEOUT_SECONDS apply to future model calls.",
         "# ENGINE_WORKSPACE_SETUP_CONCURRENCY requires an engine recreation to take effect.",
-        "# ENGINE_CODEX_HOME is the Codex home copied into future job workspaces.",
-        "# ENGINE_CLAUDE_HOME is the Claude home copied into future job workspaces.",
+        "# ENGINE_POST_PROCESS_WORKSPACE_MODE=image uses immutable Docker snapshots for workflow and post-processing jobs.",
+        "# Accounts updates ENGINE_CODEX_HOME and ENGINE_CLAUDE_HOME live; no engine restart is required.",
+        "# Each list controls the provider homes copied into future job workspaces.",
         "",
     ]
     lines.extend(f"{key}={_quote_env_value(value)}" for key, value in values.items())

--- a/engine/open_kritt_engine/worker.py
+++ b/engine/open_kritt_engine/worker.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import random
 import shutil
 import threading
@@ -47,6 +46,7 @@ from .storage_cleanup import prune_docker_build_cache, prune_stopped_scan_contai
 from .workspace import (
     cleanup_job_workspace,
     cleanup_workspace,
+    image_workspace_enabled,
     mark_provider_account_available,
     mark_provider_account_rate_limited,
     prepare_dependency_workspace,
@@ -62,6 +62,7 @@ from .workspace import (
     workspace_context,
     workspace_prompt_context,
 )
+from .workspace_snapshots import cleanup_stale_workspace_snapshot_builders
 
 LOGGER = logging.getLogger("open_kritt_engine")
 NON_RUNNABLE_SCAN_STATUSES = {"queued", "pending", "rate_limited", "paused", "stopped", "failed", "completed"}
@@ -151,9 +152,13 @@ class Worker:
     def __init__(self, config: EngineConfig, db: Database | None = None):
         self.config = config
         self.db = db or Database(config.database_url)
-        self.post_processor = PostProcessor(config, self.db)
         setup_concurrency = max(1, int(getattr(config, "workspace_setup_concurrency", 1)))
         self.workspace_setup_slots = threading.BoundedSemaphore(setup_concurrency)
+        self.post_processor = PostProcessor(
+            config,
+            self.db,
+            workspace_setup_slots=self.workspace_setup_slots,
+        )
         self._prewarm_lock = threading.Lock()
         self._prewarmed_scan_cache_keys: set[tuple[int, str]] = set()
         self._prewarm_events: dict[tuple[int, str], threading.Event] = {}
@@ -161,6 +166,7 @@ class Worker:
         self._scan_scheduler_lock = threading.Lock()
         self._scan_allocations: dict[int, int] = {}
         self._scan_last_dispatch: dict[int, int] = {}
+        self._scan_no_work_until: dict[int, float] = {}
         self._scan_dispatch_sequence = 0
         self.codex_cli_gate = CodexCliGate()
         self.generation_runner = GenerationRunner(config, codex_cli_gate=self.codex_cli_gate)
@@ -198,6 +204,7 @@ class Worker:
         last_desired: int | None = None
         LOGGER.info("open-kritt engine started; live config: %s", runtime_config_path(self.config.data_dir))
         cleanup_stale_scan_sandboxes()
+        cleanup_stale_workspace_snapshot_builders()
         if hasattr(self.db, "connect"):
             self.recover_orphaned_metadata(now_utc())
             try:
@@ -755,6 +762,7 @@ class Worker:
                     self.db.set_scan_status_if_active(conn, int(scan["id"]), "failed", error=str(exc))
                     conn.commit()
                 return True
+            self._record_scan_claim_result(int(scan["id"]), did_work=did_work)
             if did_work:
                 LOGGER.info("worker %s made progress on scan %s (%s)", worker_id, scan["id"], scan["repo_full"])
             return did_work
@@ -811,8 +819,17 @@ class Worker:
             self._scan_scheduler_lock = threading.Lock()
             self._scan_allocations = {}
             self._scan_last_dispatch = {}
+            self._scan_no_work_until = {}
             self._scan_dispatch_sequence = 0
         return self._scan_scheduler_lock
+
+    def _record_scan_claim_result(self, scan_id: int, *, did_work: bool) -> None:
+        with self._scheduler_state():
+            if did_work:
+                self._scan_no_work_until.pop(scan_id, None)
+                return
+            retry_seconds = max(0.01, float(getattr(self.config, "poll_seconds", 5.0) or 5.0))
+            self._scan_no_work_until[scan_id] = time.monotonic() + retry_seconds
 
     def _reserve_scan(self) -> dict[str, Any] | None:
         with self._scheduler_state():
@@ -836,10 +853,15 @@ class Worker:
             self._scan_last_dispatch = {
                 scan_id: sequence for scan_id, sequence in self._scan_last_dispatch.items() if scan_id in active_ids
             }
+            self._scan_no_work_until = {
+                scan_id: retry_at for scan_id, retry_at in self._scan_no_work_until.items() if scan_id in active_ids
+            }
 
-            fair_cap = max(1, math.ceil(self.runtime_worker_count() / len(scans)))
+            worker_limit = max(1, self.runtime_worker_count())
+            if sum(self._scan_allocations.values()) >= worker_limit:
+                return None
             configured_cap = self.runtime_max_workers_per_scan()
-            default_scan_cap = min(fair_cap, configured_cap) if configured_cap > 0 else fair_cap
+            default_scan_cap = min(worker_limit, configured_cap) if configured_cap > 0 else worker_limit
 
             def scan_cap(scan: dict[str, Any]) -> int:
                 reasoning = scan.get("reasoning")
@@ -848,7 +870,13 @@ class Worker:
                     return min(default_scan_cap, adaptive_cap)
                 return default_scan_cap
 
-            eligible = [scan for scan in scans if self._scan_allocations.get(int(scan["id"]), 0) < scan_cap(scan)]
+            now = time.monotonic()
+            eligible = [
+                scan
+                for scan in scans
+                if self._scan_allocations.get(int(scan["id"]), 0) < scan_cap(scan)
+                and self._scan_no_work_until.get(int(scan["id"]), 0.0) <= now
+            ]
             if not eligible:
                 return None
             selected = min(
@@ -1168,6 +1196,7 @@ class Worker:
                         agent_skills=agent_skills,
                         harness_name=harness_name,
                         model_provider=model_provider,
+                        use_snapshot_image=image_workspace_enabled(data_dir=getattr(self.config, "data_dir", None)),
                     )
                     checked_out_commit = prepared.checked_out_commit
                     context = {**state.context, **workspace_context(prepared)}
@@ -1198,8 +1227,8 @@ class Worker:
                                 prompt_filled=prompt_filled,
                                 phase="interrupted",
                                 codex_source_home=getattr(prepared.workspace, "codex_source_home", None),
-                                codex_account_id=getattr(prepared.workspace, "codex_account_id", None),
-                                codex_account_email=getattr(prepared.workspace, "codex_account_email", None),
+                                codex_account_id=getattr(prepared.workspace, "provider_account_id", None),
+                                codex_account_email=getattr(prepared.workspace, "provider_account_email", None),
                             )
                             conn.commit()
                             return True
@@ -1214,8 +1243,8 @@ class Worker:
                             prompt_filled=prompt_filled,
                             phase="running_harness",
                             codex_source_home=getattr(prepared.workspace, "codex_source_home", None),
-                            codex_account_id=getattr(prepared.workspace, "codex_account_id", None),
-                            codex_account_email=getattr(prepared.workspace, "codex_account_email", None),
+                            codex_account_id=getattr(prepared.workspace, "provider_account_id", None),
+                            codex_account_email=getattr(prepared.workspace, "provider_account_email", None),
                         )
                         conn.commit()
                 except ClaudeCredentialRateLimited as exc:
@@ -1281,13 +1310,19 @@ class Worker:
                         getattr(prepared.workspace, "provider_account_home", None),
                         data_dir=getattr(self.config, "data_dir", None),
                     ):
+                        harness_arguments = {
+                            "prompt": prompt_filled,
+                            "schema": schema,
+                            "repo_dir": prepared.repo_dir,
+                            "model": selection.model,
+                            "thinking_effort": thinking_effort,
+                            "env": prepared.workspace.env,
+                        }
+                        runner_image = getattr(prepared, "runner_image", None)
+                        if runner_image:
+                            harness_arguments["runner_image"] = runner_image
                         result = harness.run(
-                            prompt=prompt_filled,
-                            schema=schema,
-                            repo_dir=prepared.repo_dir,
-                            model=selection.model,
-                            thinking_effort=thinking_effort,
-                            env=prepared.workspace.env,
+                            **harness_arguments,
                         )
                     mark_provider_account_available(
                         getattr(prepared.workspace, "provider_account_provider", None),
@@ -1392,10 +1427,10 @@ class Worker:
                             codex_source_home=getattr(prepared.workspace, "codex_source_home", None)
                             if prepared
                             else None,
-                            codex_account_id=getattr(prepared.workspace, "codex_account_id", None)
+                            codex_account_id=getattr(prepared.workspace, "provider_account_id", None)
                             if prepared
                             else None,
-                            codex_account_email=getattr(prepared.workspace, "codex_account_email", None)
+                            codex_account_email=getattr(prepared.workspace, "provider_account_email", None)
                             if prepared
                             else None,
                             phase="failed",

--- a/engine/open_kritt_engine/workspace.py
+++ b/engine/open_kritt_engine/workspace.py
@@ -31,6 +31,10 @@ from .repository import (
     snapshot_local_repo,
 )
 from .runtime_config import runtime_int, runtime_value
+from .workspace_snapshots import (
+    WorkspaceSnapshotError,
+    ensure_workspace_snapshot_image,
+)
 
 _PROVIDER_HOME_LOCK = threading.Lock()
 _PROVIDER_HOME_CURSORS: dict[str, int] = {}
@@ -52,6 +56,7 @@ JOB_UID_BASE = 100_000
 JOB_UID_SPAN = 2_000_000_000
 _SHARED_WORKSPACE_LOCKS: dict[str, threading.Lock] = {}
 _SHARED_WORKSPACE_LOCKS_GUARD = threading.Lock()
+IMAGE_WORKSPACE_MODES = {"image", "snapshot", "snapshot_image"}
 
 
 @dataclass(frozen=True)
@@ -62,8 +67,12 @@ class JobWorkspace:
     codex_source_home: str | None = None
     codex_account_id: str | None = None
     codex_account_email: str | None = None
+    # Provider-neutral identity is written through the database's legacy
+    # codex_account_* attribution columns until that schema is generalized.
     provider_account_provider: str | None = None
     provider_account_home: str | None = None
+    provider_account_id: str | None = None
+    provider_account_email: str | None = None
 
 
 @dataclass(frozen=True)
@@ -75,6 +84,8 @@ class DependencyWorkspace:
     layout: str
     manifest_json: str
     setup_timings_ms: dict[str, int] | None = None
+    source_repo_dir: str | None = None
+    runner_image: str | None = None
 
 
 @dataclass(frozen=True)
@@ -96,6 +107,15 @@ class _ProviderAccountGate:
 class _ProviderAccountHealth:
     available: bool
     observed_at: float | None
+
+
+def image_workspace_enabled(*, data_dir: str | None = None) -> bool:
+    mode = runtime_value(
+        "ENGINE_POST_PROCESS_WORKSPACE_MODE",
+        "copy",
+        data_dir=data_dir,
+    )
+    return str(mode or "copy").strip().lower() in IMAGE_WORKSPACE_MODES
 
 
 def prepare_job_workspace(
@@ -135,7 +155,13 @@ def prepare_job_workspace(
         if needs_claude_home and selected_provider == "claude"
         else None
     )
-    codex_account = _codex_account_info(codex_source) if codex_source else {}
+    provider_account = (
+        _codex_account_info(codex_source)
+        if codex_source
+        else _claude_account_info(claude_source)
+        if claude_source
+        else {}
+    )
     if needs_codex_home and codex_source:
         _copy_credential_files(Path(codex_source), codex_home, ("auth.json",))
     elif needs_codex_home:
@@ -180,10 +206,12 @@ def prepare_job_workspace(
         repo_base_dir=str(repo_base),
         env=env,
         codex_source_home=codex_source,
-        codex_account_id=codex_account.get("id"),
-        codex_account_email=codex_account.get("email"),
+        codex_account_id=provider_account.get("id") if codex_source else None,
+        codex_account_email=provider_account.get("email") if codex_source else None,
         provider_account_provider=selected_provider if selected_provider in {"codex", "claude"} else None,
         provider_account_home=codex_source or claude_source,
+        provider_account_id=provider_account.get("id"),
+        provider_account_email=provider_account.get("email"),
     )
 
 
@@ -311,6 +339,7 @@ def prepare_dependency_workspace(
     agent_skills: list[dict[str, Any]] | None = None,
     harness_name: str | None = None,
     model_provider: str | None = None,
+    use_snapshot_image: bool = False,
 ) -> DependencyWorkspace:
     scan = resolve_scan_checkout_revisions(scan, github_token=github_token, data_dir=data_dir)
     total_started = time.perf_counter()
@@ -324,6 +353,42 @@ def prepare_dependency_workspace(
         model_provider=model_provider,
     )
     timings["job_home_ms"] = _elapsed_ms(home_started)
+    if use_snapshot_image:
+        try:
+            prepared = _prepare_dependency_snapshot_workspace(
+                workspace=workspace,
+                cache_dir=_checkout_cache_dir(checkout_cache_dir),
+                scan=scan,
+                github_token=github_token,
+                timings=timings,
+            )
+            timings["total_ms"] = _elapsed_ms(total_started)
+            LOGGER.info(
+                "prepared image workspace for metadata %s scan %s in %sms using %s: %s",
+                metadata_id,
+                scan.get("id"),
+                timings["total_ms"],
+                prepared.runner_image,
+                timings,
+            )
+            return DependencyWorkspace(
+                workspace=prepared.workspace,
+                repo_dir=prepared.repo_dir,
+                checked_out_commit=prepared.checked_out_commit,
+                manifest=prepared.manifest,
+                layout=prepared.layout,
+                manifest_json=prepared.manifest_json,
+                setup_timings_ms=timings,
+                source_repo_dir=prepared.source_repo_dir,
+                runner_image=prepared.runner_image,
+            )
+        except WorkspaceSnapshotError as exc:
+            LOGGER.warning(
+                "workspace snapshot unavailable for metadata %s scan %s; falling back to a physical copy: %s",
+                metadata_id,
+                scan.get("id"),
+                exc,
+            )
     # Every harness gets a writable per-job copy. The nested runner is disposable,
     # so agents can compile targets and create proof-of-concept artifacts freely.
     cache_dir = _checkout_cache_dir(checkout_cache_dir)
@@ -358,6 +423,103 @@ def prepare_dependency_workspace(
         layout=prepared_tree.layout,
         manifest_json=prepared_tree.manifest_json,
         setup_timings_ms=timings,
+    )
+
+
+def _prepare_dependency_snapshot_workspace(
+    *,
+    workspace: JobWorkspace,
+    cache_dir: Path,
+    scan: dict[str, Any],
+    github_token: str | None,
+    timings: dict[str, int] | None = None,
+) -> DependencyWorkspace:
+    primary_kind = scan.get("repo_kind") or "remote"
+    requested_commit = _requested_revision(primary_kind, scan.get("commit_sha"))
+    cache_started = time.perf_counter()
+    primary_cache_checkout, checked_out_commit = _checkout_scan_repo_to_cache(
+        cache_dir=cache_dir,
+        kind=primary_kind,
+        repo_full=scan["repo_full"],
+        commit_sha=requested_commit,
+        github_token=github_token,
+        scan_id=scan.get("id"),
+    )
+    _add_timing(timings, "checkout_cache_ms", _elapsed_ms(cache_started))
+
+    sources = [(primary_cache_checkout, SCAN_RUNNER_WORKDIR)]
+    dependencies = []
+    used_aliases: set[str] = set(RESERVED_WORKSPACE_ENTRIES)
+    for dep in _scan_dependencies(scan):
+        kind = dep.get("kind") or "remote"
+        repo_full = dep.get("repo_full") or dep.get("repoFull") or ""
+        commit_sha = _requested_revision(kind, dep.get("commit_sha") or dep.get("commitSha"))
+        if not repo_full:
+            continue
+        alias = _dependency_alias(SCAN_RUNNER_WORKDIR, repo_full, used_aliases)
+        used_aliases.add(alias)
+        cache_started = time.perf_counter()
+        dep_cache_checkout, dep_commit = _checkout_scan_repo_to_cache(
+            cache_dir=cache_dir,
+            kind=kind,
+            repo_full=repo_full,
+            commit_sha=commit_sha,
+            github_token=github_token,
+            scan_id=scan.get("id"),
+        )
+        _add_timing(timings, "checkout_cache_ms", _elapsed_ms(cache_started))
+        dependency_path = f"{SCAN_RUNNER_WORKDIR}/{alias}"
+        sources.append((dep_cache_checkout, dependency_path))
+        dependencies.append(
+            {
+                "kind": kind,
+                "repo": repo_full,
+                "requested_commit": commit_sha,
+                "commit": dep_commit,
+                "alias": alias,
+                "path": dependency_path,
+                "relative_path": alias,
+            }
+        )
+
+    manifest = {
+        "primary": {
+            "kind": primary_kind,
+            "repo": scan["repo_full"],
+            "requested_commit": requested_commit,
+            "commit": checked_out_commit,
+            "path": SCAN_RUNNER_WORKDIR,
+        },
+        "dependencies": dependencies,
+    }
+    manifest_json = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
+    layout = workspace_layout(SCAN_RUNNER_WORKDIR, manifest)
+    repo_dir = Path(workspace.root_dir) / "workspace"
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    _write_workspace_files(str(repo_dir), manifest, layout, manifest_json)
+
+    image_started = time.perf_counter()
+    runner_image = ensure_workspace_snapshot_image(
+        base_image=os.getenv("ENGINE_SCAN_RUNNER_IMAGE", "open-kritt-engine:local"),
+        checkout_key=scan_checkout_cache_key(scan),
+        manifest_json=manifest_json,
+        workspace_files_dir=str(repo_dir),
+        sources=sources,
+        scan_id=scan.get("id"),
+    )
+    _add_timing(timings, "snapshot_image_ms", _elapsed_ms(image_started))
+    job_uid = int(workspace.env["OPEN_KRITT_JOB_UID"])
+    job_gid = int(workspace.env["OPEN_KRITT_JOB_GID"])
+    _secure_job_tree(Path(workspace.root_dir), job_uid, job_gid)
+    return DependencyWorkspace(
+        workspace=workspace,
+        repo_dir=str(repo_dir),
+        checked_out_commit=checked_out_commit,
+        manifest=manifest,
+        layout=layout,
+        manifest_json=manifest_json,
+        source_repo_dir=primary_cache_checkout,
+        runner_image=runner_image,
     )
 
 
@@ -1483,6 +1645,55 @@ def _codex_account_info(home: str) -> dict[str, str | None]:
     email = payload.get("email")
     return {
         "id": auth_info.get("chatgpt_account_id") or payload.get("sub") or email or str(home),
+        "email": email,
+    }
+
+
+def _first_account_profile_value(value: Any, keys: set[str]) -> str | None:
+    if not isinstance(value, dict | list):
+        return None
+    values = value.values() if isinstance(value, dict) else value
+    if isinstance(value, dict):
+        for key, candidate in value.items():
+            normalized_key = "".join(character for character in key.lower() if character.isalnum())
+            if normalized_key in keys and isinstance(candidate, str | int):
+                text = str(candidate).strip()
+                if text:
+                    return text
+    for candidate in values:
+        found = _first_account_profile_value(candidate, keys)
+        if found:
+            return found
+    return None
+
+
+def _claude_account_info(home: str) -> dict[str, str | None]:
+    source = Path(home)
+    candidates = [
+        source / ".open-kritt-account.json",
+        source / ".claude.json",
+        source / "claude.json",
+    ]
+    if source.name == ".claude":
+        candidates.append(source.parent / ".claude.json")
+    payloads: list[Any] = []
+    for path in candidates:
+        try:
+            if path.stat().st_size > 1024 * 1024:
+                continue
+            payloads.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            continue
+    email = _first_account_profile_value(
+        payloads,
+        {"email", "emailaddress", "useremail", "accountemail"},
+    )
+    account_id = _first_account_profile_value(
+        payloads,
+        {"accountid", "accountuuid", "userid", "useruuid"},
+    )
+    return {
+        "id": account_id or email or str(home),
         "email": email,
     }
 

--- a/engine/open_kritt_engine/workspace_snapshots.py
+++ b/engine/open_kritt_engine/workspace_snapshots.py
@@ -1,0 +1,266 @@
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+LOGGER = logging.getLogger("open_kritt_engine.workspace_snapshots")
+SNAPSHOT_LABEL = "open-kritt.workspace-snapshot"
+SNAPSHOT_KEY_LABEL = "open-kritt.workspace-snapshot-key"
+SNAPSHOT_BUILDER_LABEL = "open-kritt.workspace-snapshot-builder"
+SNAPSHOT_LEASE_LABEL = "open-kritt.workspace-snapshot-lease"
+SNAPSHOT_FORMAT_VERSION = 1
+SNAPSHOT_IMAGE_REPOSITORY = "open-kritt-workspace-snapshot"
+_SNAPSHOT_LOCKS: dict[str, threading.Lock] = {}
+_SNAPSHOT_LOCKS_GUARD = threading.Lock()
+
+
+class WorkspaceSnapshotError(RuntimeError):
+    pass
+
+
+def _docker_environment() -> dict[str, str]:
+    keys = ("PATH", "HOME", "DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG", "XDG_RUNTIME_DIR")
+    return {key: value for key in keys if (value := os.environ.get(key))}
+
+
+def _docker_binary() -> str:
+    docker = shutil.which(os.getenv("ENGINE_DOCKER_BIN", "docker"))
+    if not docker:
+        raise WorkspaceSnapshotError("Docker is required to build scan workspace snapshots.")
+    return docker
+
+
+def _run_docker(
+    arguments: list[str],
+    *,
+    timeout_seconds: float = 600.0,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    command = [_docker_binary(), *arguments]
+    try:
+        completed = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+            env=_docker_environment(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise WorkspaceSnapshotError(f"Docker command failed to start: {arguments[0]}") from exc
+    if check and completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()[-1000:]
+        raise WorkspaceSnapshotError(f"Docker {arguments[0]} failed: {detail or 'unknown error'}")
+    return completed
+
+
+def _snapshot_lock(key: str) -> threading.Lock:
+    with _SNAPSHOT_LOCKS_GUARD:
+        lock = _SNAPSHOT_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SNAPSHOT_LOCKS[key] = lock
+        return lock
+
+
+def _base_image_id(base_image: str) -> str:
+    result = _run_docker(["image", "inspect", "--format", "{{.Id}}", base_image], timeout_seconds=30)
+    image_id = result.stdout.strip()
+    if not image_id:
+        raise WorkspaceSnapshotError(f"Scan runner image is unavailable: {base_image}")
+    return image_id
+
+
+def workspace_snapshot_key(
+    *,
+    base_image_id: str,
+    checkout_key: str,
+    manifest_json: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "format_version": SNAPSHOT_FORMAT_VERSION,
+            "base_image_id": base_image_id,
+            "checkout_key": checkout_key,
+            "manifest_json": manifest_json,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def workspace_snapshot_image_name(key: str) -> str:
+    return f"{SNAPSHOT_IMAGE_REPOSITORY}:{key[:32]}"
+
+
+def _snapshot_container_name(kind: str, key: str) -> str:
+    return f"open-kritt-workspace-{kind}-{key[:24]}"
+
+
+def _image_snapshot_key(image: str) -> str | None:
+    result = _run_docker(
+        ["image", "inspect", "--format", f'{{{{ index .Config.Labels "{SNAPSHOT_KEY_LABEL}" }}}}', image],
+        timeout_seconds=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _remove_container(name: str):
+    _run_docker(["rm", "--force", name], timeout_seconds=60, check=False)
+
+
+def _ensure_snapshot_lease(image: str, key: str):
+    name = _snapshot_container_name("lease", key)
+    inspected = _run_docker(
+        ["container", "inspect", "--format", "{{.Image}}", name],
+        timeout_seconds=30,
+        check=False,
+    )
+    image_id = _run_docker(["image", "inspect", "--format", "{{.Id}}", image], timeout_seconds=30).stdout.strip()
+    if inspected.returncode == 0 and inspected.stdout.strip() == image_id:
+        return
+    if inspected.returncode == 0:
+        _remove_container(name)
+    _run_docker(
+        [
+            "create",
+            "--name",
+            name,
+            "--label",
+            f"{SNAPSHOT_LEASE_LABEL}=1",
+            "--label",
+            f"{SNAPSHOT_KEY_LABEL}={key}",
+            image,
+            "/bin/true",
+        ],
+        timeout_seconds=60,
+    )
+
+
+def ensure_workspace_snapshot_image(
+    *,
+    base_image: str,
+    checkout_key: str,
+    manifest_json: str,
+    workspace_files_dir: str,
+    sources: list[tuple[str, str]],
+    scan_id: int | str | None = None,
+) -> str:
+    base_id = _base_image_id(base_image)
+    key = workspace_snapshot_key(
+        base_image_id=base_id,
+        checkout_key=checkout_key,
+        manifest_json=manifest_json,
+    )
+    image = workspace_snapshot_image_name(key)
+    with _snapshot_lock(key):
+        if _image_snapshot_key(image) == key:
+            _ensure_snapshot_lease(image, key)
+            return image
+
+        started = time.perf_counter()
+        builder = _snapshot_container_name("builder", key)
+        _remove_container(builder)
+        try:
+            create_arguments = [
+                "create",
+                "--name",
+                builder,
+                "--label",
+                f"{SNAPSHOT_BUILDER_LABEL}=1",
+                "--label",
+                f"{SNAPSHOT_KEY_LABEL}={key}",
+                base_image,
+                "/bin/true",
+            ]
+            _run_docker(create_arguments, timeout_seconds=60)
+            for source, destination in sources:
+                source_path = Path(source)
+                if not source_path.is_dir():
+                    raise WorkspaceSnapshotError(f"Workspace snapshot source is unavailable: {source}")
+                _run_docker(
+                    ["cp", f"{source_path}/.", f"{builder}:{destination}"],
+                    timeout_seconds=600,
+                )
+            for filename in ("WORKSPACE.json", "WORKSPACE.md"):
+                source_file = Path(workspace_files_dir) / filename
+                if not source_file.is_file():
+                    raise WorkspaceSnapshotError(f"Workspace snapshot metadata is unavailable: {source_file}")
+                _run_docker(
+                    ["cp", str(source_file), f"{builder}:/workspace/{filename}"],
+                    timeout_seconds=60,
+                )
+            changes = [
+                "--change",
+                "WORKDIR /workspace",
+                "--change",
+                f"LABEL {SNAPSHOT_LABEL}=1",
+                "--change",
+                f"LABEL {SNAPSHOT_KEY_LABEL}={key}",
+                "--change",
+                f"LABEL {SNAPSHOT_BUILDER_LABEL}=0",
+            ]
+            if scan_id is not None:
+                changes.extend(["--change", f"LABEL open-kritt.workspace-scan-id={scan_id}"])
+            _run_docker(
+                ["commit", *changes, builder, image],
+                timeout_seconds=600,
+            )
+        finally:
+            _remove_container(builder)
+
+        if _image_snapshot_key(image) != key:
+            raise WorkspaceSnapshotError("Docker did not publish the expected workspace snapshot image.")
+        _ensure_snapshot_lease(image, key)
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        LOGGER.info("built workspace snapshot image %s for scan %s in %sms", image, scan_id, elapsed_ms)
+        return image
+
+
+def cleanup_stale_workspace_snapshot_builders():
+    result = _run_docker(
+        ["ps", "--all", "--quiet", "--filter", f"label={SNAPSHOT_BUILDER_LABEL}=1"],
+        timeout_seconds=30,
+        check=False,
+    )
+    for container_id in result.stdout.split():
+        lease = _run_docker(
+            [
+                "container",
+                "inspect",
+                "--format",
+                f'{{{{ index .Config.Labels "{SNAPSHOT_LEASE_LABEL}" }}}}',
+                container_id,
+            ],
+            timeout_seconds=30,
+            check=False,
+        )
+        if lease.returncode == 0 and lease.stdout.strip() == "1":
+            continue
+        _run_docker(["rm", "--force", container_id], timeout_seconds=60, check=False)
+
+
+def workspace_snapshot_metadata(image: str) -> dict[str, Any] | None:
+    result = _run_docker(
+        ["image", "inspect", "--format", "{{json .Config.Labels}}", image],
+        timeout_seconds=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        labels = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return labels if isinstance(labels, dict) else None

--- a/engine/tests/test_engine.py
+++ b/engine/tests/test_engine.py
@@ -23,7 +23,15 @@ from open_kritt_engine.harnesses import (
     HarnessOutput,
     HarnessResult,
 )
-from open_kritt_engine.models import Job, State, Step, StepResultRow, Workflow, model_selection_for_depth
+from open_kritt_engine.models import (
+    Job,
+    State,
+    Step,
+    StepResultRow,
+    Workflow,
+    model_selection_for_depth,
+    post_processing_thinking_effort,
+)
 from open_kritt_engine.post_processing import (
     PostProcessor,
     PostProcessRateLimited,
@@ -52,6 +60,7 @@ from open_kritt_engine.runtime_config import ensure_runtime_config_file
 from open_kritt_engine.schema import EXTRACTOR_HELPER_FIELD, OutputValidationError, output_schema, validate_payload
 from open_kritt_engine.worker import Worker
 from open_kritt_engine.workspace import (
+    _configured_claude_homes,
     _configured_codex_homes,
     _dependency_alias,
     cleanup_job_workspace,
@@ -132,6 +141,17 @@ def test_model_selection_resolves_depth_override_and_keeps_default_for_post_proc
     assert model_selection_for_depth(configured, 1).model_provider == "claude"
     assert model_selection_for_depth(configured, 0).model == "test-model"
     assert model_selection_for_depth(configured).model == "test-model"
+
+
+def test_post_processing_thinking_effort_is_independent_from_workflow_effort():
+    configured = {
+        **scan({"post_processing_thinking_effort": "medium"}),
+        "thinking_effort": "high",
+    }
+
+    assert model_selection_for_depth(configured).thinking_effort == "high"
+    assert post_processing_thinking_effort(configured) == "medium"
+    assert post_processing_thinking_effort({**configured, "configuration": {}}) == "high"
 
 
 def fake_cache_git_head(path):
@@ -521,6 +541,50 @@ def test_prepare_dependency_workspace_writes_manifest_and_layout(monkeypatch, tm
     bundle_text = bundle_file.read_text(encoding="utf-8")
     assert 'name: "open-kritt-selected-skills"' in bundle_text
     assert "Trace attacker input to sinks." in bundle_text
+
+
+def test_prepare_dependency_workspace_uses_cached_snapshot_image_without_copying_worktree(monkeypatch, tmp_path):
+    def fake_checkout_repo(repo_full, commit_sha, base_dir, github_token=None):
+        path = Path(base_dir) / repo_full.replace("/", "__")
+        path.mkdir(parents=True, exist_ok=True)
+        (path / ".git").mkdir(exist_ok=True)
+        (path / "repo.txt").write_text(repo_full, encoding="utf-8")
+        return str(path), f"commit-{repo_full.split('/')[-1]}"
+
+    captured = {}
+
+    def fake_snapshot_image(**kwargs):
+        captured.update(kwargs)
+        return "open-kritt-workspace-snapshot:test"
+
+    monkeypatch.setattr(workspace_module, "checkout_repo", fake_checkout_repo)
+    monkeypatch.setattr(workspace_module, "_git_head_commit", fake_cache_git_head)
+    monkeypatch.setattr(workspace_module, "ensure_workspace_snapshot_image", fake_snapshot_image)
+    monkeypatch.setattr(
+        workspace_module,
+        "copy_checkout",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("snapshot mode must not copy worktrees")),
+    )
+
+    prepared = prepare_dependency_workspace(
+        data_dir=str(tmp_path / "data"),
+        checkout_cache_dir=str(tmp_path / "cache"),
+        metadata_id=47,
+        scan={
+            **scan(),
+            "commit_sha": "abc123",
+            "dependencies_detail": [{"kind": "remote", "repo_full": "anza-xyz/agave", "commit_sha": "def456"}],
+        },
+        use_snapshot_image=True,
+    )
+
+    assert prepared.runner_image == "open-kritt-workspace-snapshot:test"
+    assert prepared.source_repo_dir == captured["sources"][0][0]
+    assert captured["sources"][0][1] == "/workspace"
+    assert captured["sources"][1][1] == "/workspace/agave"
+    assert Path(prepared.repo_dir).is_dir()
+    assert {path.name for path in Path(prepared.repo_dir).iterdir()} == {"WORKSPACE.json", "WORKSPACE.md"}
+    assert json.loads(prepared.manifest_json)["primary"]["path"] == "/workspace"
 
 
 def test_prewarm_scan_checkout_cache_only_populates_cache(monkeypatch, tmp_path):
@@ -1680,6 +1744,10 @@ def test_job_workspace_copies_only_claude_credentials(monkeypatch, tmp_path):
     (backup_dir / ".claude.json.backup.123").write_text('{"restored":true}', encoding="utf-8")
     credential = '{"claudeAiOauth":{"accessToken":"test","refreshToken":"refresh","expiresAt":9999999999999}}'
     (claude_home / ".credentials.json").write_text(credential, encoding="utf-8")
+    (claude_home / ".open-kritt-account.json").write_text(
+        '{"provider":"claude","accountId":"claude-account-id","email":"researcher@example.test"}',
+        encoding="utf-8",
+    )
     (claude_home / "settings.json").write_text('{"hooks":{"PreToolUse":"leak"}}', encoding="utf-8")
     monkeypatch.setenv("CLAUDE_HOME", str(claude_home))
 
@@ -1695,6 +1763,12 @@ def test_job_workspace_copies_only_claude_credentials(monkeypatch, tmp_path):
     assert (job_claude_home / ".claude.json").read_text(encoding="utf-8") == "{}\n"
     assert not (job_claude_home / "backups").exists()
     assert not (job_claude_home / "settings.json").exists()
+    assert workspace.provider_account_provider == "claude"
+    assert workspace.provider_account_home == str(claude_home)
+    assert workspace.provider_account_id == "claude-account-id"
+    assert workspace.provider_account_email == "researcher@example.test"
+    assert workspace.codex_account_id is None
+    assert workspace.codex_account_email is None
 
 
 def test_job_workspace_rotates_between_configured_codex_homes(monkeypatch, tmp_path):
@@ -1722,6 +1796,35 @@ def test_job_workspace_rotates_between_configured_codex_homes(monkeypatch, tmp_p
     assert (Path(workspace_1.env["CODEX_HOME"]) / "auth.json").read_text(encoding="utf-8") == '{"account":"a"}'
     assert (Path(workspace_2.env["CODEX_HOME"]) / "auth.json").read_text(encoding="utf-8") == '{"account":"b"}'
     assert (Path(workspace_3.env["CODEX_HOME"]) / "auth.json").read_text(encoding="utf-8") == '{"account":"a"}'
+
+
+def test_claude_rotation_reloads_live_account_list_without_engine_restart(monkeypatch, tmp_path):
+    monkeypatch.delenv("ENGINE_RUNTIME_CONFIG_PATH", raising=False)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    runtime_path = data_dir / "engine-runtime.env"
+    home_a = tmp_path / "claude-accounts" / "account-a" / ".claude"
+    home_b = tmp_path / "claude-accounts" / "account-b" / ".claude"
+    home_a.mkdir(parents=True)
+    home_b.mkdir(parents=True)
+    (home_a / ".credentials.json").write_text("{}", encoding="utf-8")
+    (home_b / ".credentials.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(workspace_module, "_provider_account_health", lambda _provider: {})
+
+    runtime_path.write_text(f"ENGINE_CLAUDE_HOME={home_a}\n", encoding="utf-8")
+    assert _configured_claude_homes(data_dir=str(data_dir)) == [str(home_a)]
+    assert provider_home_for_job("claude", 1, data_dir=str(data_dir)) == str(home_a)
+
+    runtime_path.write_text(f"ENGINE_CLAUDE_HOME={home_a},{home_b}\n", encoding="utf-8")
+    assert _configured_claude_homes(data_dir=str(data_dir)) == [str(home_a), str(home_b)]
+    assert {
+        provider_home_for_job("claude", 2, data_dir=str(data_dir)),
+        provider_home_for_job("claude", 3, data_dir=str(data_dir)),
+    } == {str(home_a), str(home_b)}
+
+    runtime_path.write_text(f"ENGINE_CLAUDE_HOME={home_b}\n", encoding="utf-8")
+    assert _configured_claude_homes(data_dir=str(data_dir)) == [str(home_b)]
+    assert provider_home_for_job("claude", 4, data_dir=str(data_dir)) == str(home_b)
 
 
 @pytest.mark.parametrize("provider", ["codex", "claude"])
@@ -2457,6 +2560,51 @@ def test_worker_retries_strict_validation_then_writes_results(monkeypatch, tmp_p
     assert fake_db.metadata[0]["harness"] == "claude-code"
     assert fake_db.metadata[0]["model_provider"] == "claude"
     assert fake_db.step_results[0]["json_answer"] == {"thing": "ok"}
+    assert not root.exists()
+
+
+def test_worker_uses_snapshot_image_for_normal_workflow_jobs(monkeypatch, tmp_path):
+    runtime_path = tmp_path / "engine-runtime.env"
+    runtime_path.write_text("ENGINE_POST_PROCESS_WORKSPACE_MODE=image\n", encoding="utf-8")
+    monkeypatch.setenv("ENGINE_RUNTIME_CONFIG_PATH", str(runtime_path))
+    root = tmp_path / "job"
+    root.mkdir()
+
+    class Workspace:
+        root_dir = str(root)
+        env = {"HOME": str(tmp_path / "home")}
+
+    prepared = SimpleNamespace(
+        workspace=Workspace(),
+        repo_dir=str(root / "workspace"),
+        checked_out_commit="abc",
+        layout="Dependency repositories are checked out as top-level directories inside the same workspace root.",
+        manifest_json='{"dependencies":[]}',
+        runner_image="open-kritt-workspace-snapshot:test",
+    )
+    fake_db = FakeDb()
+    worker = Worker(
+        SimpleNamespace(retry_count=0, data_dir=str(tmp_path), github_token=None),
+        db=fake_db,
+    )
+    workspace_requests = []
+    monkeypatch.setattr(
+        worker_module,
+        "prepare_dependency_workspace",
+        lambda **kwargs: workspace_requests.append(kwargs) or prepared,
+    )
+    job = Job(
+        step=step(1, 0, multi=False, output_format='{"thing":"string"}'),
+        state=State(prev_id=0, prev_table=None, repeat_run=1, context={"repo_full": "owner/repo"}),
+    )
+    fake_harness = FakeHarness([marked({"stub": False, "stub_explanation": "", "results": [{"thing": "ok"}]})])
+
+    worker.execute_job(scan=scan(), workflow_id=3, job=job, harness=fake_harness)
+
+    assert workspace_requests[0]["use_snapshot_image"] is True
+    assert fake_harness.calls[0]["runner_image"] == "open-kritt-workspace-snapshot:test"
+    assert fake_harness.calls[0]["repo_dir"] == str(root / "workspace")
+    assert fake_db.metadata[0]["status"] == "completed"
     assert not root.exists()
 
 

--- a/engine/tests/test_generation.py
+++ b/engine/tests/test_generation.py
@@ -1123,6 +1123,7 @@ def test_run_forever_starts_a_dedicated_generation_worker(monkeypatch, tmp_path)
     worker._schedule_codex_update = lambda: None
     worker._schedule_model_catalog_refresh = lambda: None
     monkeypatch.setattr(worker_module, "cleanup_stale_scan_sandboxes", lambda: None)
+    monkeypatch.setattr(worker_module, "cleanup_stale_workspace_snapshot_builders", lambda: None)
     monkeypatch.setattr(worker_module.threading, "Thread", FakeThread)
     monkeypatch.setattr(worker_module.time, "sleep", lambda _seconds: (_ for _ in ()).throw(StopRunForever()))
 

--- a/engine/tests/test_patched_since.py
+++ b/engine/tests/test_patched_since.py
@@ -107,9 +107,9 @@ def test_patched_since_fetches_remote_history_once_and_attaches_it_to_each_works
     fetches = []
     original_fetch = prompting_module._git_fetch_status
 
-    def counted_fetch(repo_dir, refspec, *, timeout):
+    def counted_fetch(repo_dir, refspec, *, timeout, github_token=None):
         fetches.append((repo_dir, refspec))
-        return original_fetch(repo_dir, refspec, timeout=timeout)
+        return original_fetch(repo_dir, refspec, timeout=timeout, github_token=github_token)
 
     monkeypatch.setattr(prompting_module, "_git_fetch_status", counted_fetch)
 
@@ -161,6 +161,10 @@ def test_patched_since_prompt_requires_newer_comparison_and_exact_fix_commit():
     assert "found_at_commit" in prompt
     assert "_chip_patched" in prompt
     assert "needs_manual_review" in prompt
+    assert "On every run, independently check the live main branch" in prompt
+    assert "`repository.workspace_path`" in prompt
+    assert "`origin/main`" in prompt
+    assert "never translate unavailable history" in prompt
     assert "4a7dfc2" in prompt
     assert "bd9ee631" in prompt
     assert "{{patched_since_history}}" not in prompt
@@ -245,6 +249,7 @@ def test_patched_since_compares_dependency_path_with_dependency_default_branch(t
     assert context["status"] == "available"
     assert context["repository"]["repo"] == "stacks-sbtc/sbtc"
     assert context["repository"]["role"] == "dependency"
+    assert context["repository"]["workspace_path"] == "/workspace/sbtc"
     assert context["finding_path"]["repo_relative"] == "signer/src/contracts.rs"
     assert context["target_commit"] == vulnerable_commit
     assert context["default_branch"]["commit"] == fixed_commit
@@ -268,3 +273,58 @@ def test_patched_since_without_newer_refs_requires_manual_review_context(tmp_pat
     assert context["newer_descendants"] == []
     assert all(item["status"] == "unavailable" for item in context["fetch_results"])
     assert "requires manual review" in context["reason"]
+
+
+def test_patched_since_passes_github_token_to_authenticated_fetch(monkeypatch, tmp_path):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _git(checkout, "init", "--initial-branch=main")
+    (checkout / "validation.rs").write_text("still vulnerable\n", encoding="utf-8")
+    target = _commit(checkout, "target")
+    _git(checkout, "remote", "add", "origin", "https://github.com/example/private.git")
+    calls = []
+
+    def fake_fetch(repo_dir, refspec, *, github_token=None, timeout):
+        calls.append((repo_dir, refspec, github_token, timeout))
+        return False, "test failure"
+
+    monkeypatch.setattr(prompting_module, "fetch_remote_ref", fake_fetch)
+
+    context = json.loads(
+        patched_since_history_context(
+            str(checkout),
+            _scan(target),
+            github_token="secret-token",
+            fetch_timeout=17,
+        )
+    )
+
+    assert context["status"] == "unavailable"
+    assert calls == [
+        (
+            str(checkout),
+            "+HEAD:refs/remotes/open-kritt-patched-since/default",
+            "secret-token",
+            17,
+        )
+    ]
+
+
+def test_patched_since_does_not_cache_transient_fetch_failure(monkeypatch, tmp_path):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _git(checkout, "init", "--initial-branch=main")
+    (checkout / "validation.rs").write_text("still vulnerable\n", encoding="utf-8")
+    target = _commit(checkout, "target")
+    calls = []
+
+    def unavailable_fetch(*_args, **_kwargs):
+        calls.append(True)
+        return False, "temporary network failure"
+
+    monkeypatch.setattr(prompting_module, "fetch_remote_ref", unavailable_fetch)
+
+    patched_since_history_context(str(checkout), _scan(target))
+    patched_since_history_context(str(checkout), _scan(target))
+
+    assert len(calls) == 2

--- a/engine/tests/test_post_processing_concurrency.py
+++ b/engine/tests/test_post_processing_concurrency.py
@@ -1,0 +1,178 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from open_kritt_engine import post_processing as post_processing_module
+from open_kritt_engine.db import Database
+from open_kritt_engine.post_processing import POST_WORKSPACE_ID_OFFSET, PostProcessor
+
+
+class FakeConnection:
+    def __init__(self):
+        self.commits = 0
+
+    def commit(self):
+        self.commits += 1
+
+
+def active_scan():
+    return {
+        "id": 146,
+        "workflow_id": 3,
+        "status": "post_processing",
+        "configuration": {},
+        "model": "test-model",
+        "harness": "codex",
+    }
+
+
+def test_process_once_schedules_post_scripts_while_another_worker_runs_ranker():
+    current = active_scan()
+
+    class FakeDatabase:
+        @contextmanager
+        def connect(self):
+            yield FakeConnection()
+
+        def load_scan(self, _conn, _scan_id):
+            return current
+
+        def load_vulnerabilities(self, _conn, _scan_id):
+            return [{"id": 127, "dedupe_is_canonical": True, "bounty_rank": None}]
+
+    processor = PostProcessor(SimpleNamespace(), FakeDatabase())
+    calls = []
+    processor._run_next_ranker_batch = lambda _scan, _harness: calls.append("ranker") and False
+
+    def run_post_script(_scan, _harness, *, allow_complete):
+        calls.append(("post_script", allow_complete))
+        return True
+
+    processor._run_next_post_script_or_complete = run_post_script
+
+    assert processor.process_once(current, object()) is True
+    assert calls == ["ranker", ("post_script", False)]
+
+
+def test_post_scripts_cannot_complete_scan_while_ranker_is_running():
+    current = active_scan()
+
+    class FakeDatabase:
+        def __init__(self):
+            self.status_updates = []
+
+        @contextmanager
+        def connect(self):
+            yield FakeConnection()
+
+        def load_scan(self, _conn, _scan_id):
+            return current
+
+        def count_running_post_process(self, _conn, _scan_id, kind):
+            return 1 if kind == "ranker" else 0
+
+        def set_scan_status_if_current(self, _conn, scan_id, current_status, next_status):
+            self.status_updates.append((scan_id, current_status, next_status))
+
+    database = FakeDatabase()
+    processor = PostProcessor(SimpleNamespace(), database)
+
+    assert processor._run_next_post_script_or_complete(current, object()) is False
+    assert database.status_updates == []
+
+
+def test_post_processing_uses_shared_workspace_setup_slot(monkeypatch):
+    events = []
+
+    class RecordingSlot:
+        def __enter__(self):
+            events.append("slot-enter")
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            events.append("slot-exit")
+
+    prepared = object()
+
+    def prepare_dependency_workspace(**kwargs):
+        events.append(("prepare", kwargs))
+        return prepared
+
+    monkeypatch.setattr(post_processing_module, "prepare_dependency_workspace", prepare_dependency_workspace)
+    processor = PostProcessor(
+        SimpleNamespace(data_dir="/tmp/data", github_token=None),
+        object(),
+        workspace_setup_slots=RecordingSlot(),
+    )
+
+    result = processor._prepare_workspace(42, active_scan(), agent_skills=[{"slug": "security-review"}])
+
+    assert result is prepared
+    assert events[0] == "slot-enter"
+    assert events[2] == "slot-exit"
+    assert events[1][0] == "prepare"
+    assert events[1][1]["metadata_id"] == POST_WORKSPACE_ID_OFFSET + 42
+    assert events[1][1]["agent_skills"] == [{"slug": "security-review"}]
+
+
+class QueryResult:
+    def __init__(self, row=None):
+        self.row = row
+
+    def fetchone(self):
+        return self.row
+
+
+class RankerClaimConnection:
+    def __init__(self, *, active_ranker=None, eligible_targets=1):
+        self.active_ranker = active_ranker
+        self.eligible_targets = eligible_targets
+        self.queries = []
+
+    def execute(self, query, params):
+        self.queries.append((query, params))
+        if "FROM public.scans" in query and "FOR UPDATE" in query:
+            return QueryResult({"id": 146, "status": "post_processing", "job_limit": None, "jobs_started": 0})
+        if "FROM workflows.post_process_metadata" in query and "status = 'running'" in query:
+            return QueryResult(self.active_ranker)
+        if "SELECT count(*) AS count" in query and "FROM workflows.vulnerabilities" in query:
+            return QueryResult({"count": self.eligible_targets})
+        return QueryResult()
+
+
+def claim_ranker(database, connection, *, batch_index=2):
+    return database.claim_post_process_metadata(
+        connection,
+        scan_id=146,
+        workflow_id=3,
+        kind="ranker",
+        batch_index=batch_index,
+        target_vulnerability_ids=[127],
+        prompt_template="anchored-ranker",
+        prompt_filled="",
+        model="test-model",
+        harness="codex",
+        thinking_effort="medium",
+        model_provider="codex",
+        run_started_at=datetime.now(timezone.utc),
+    )
+
+
+def test_ranker_claim_rechecks_for_any_active_batch_under_scan_lock():
+    connection = RankerClaimConnection(active_ranker={"id": 268})
+
+    assert claim_ranker(Database(""), connection) is None
+    assert connection.queries[0][1] == ("post-process:146:ranker",)
+    active_query = next(query for query, _params in connection.queries if "status = 'running'" in query)
+    assert "batch_index = %s AND status = 'completed'" in active_query
+    assert not any("INSERT INTO workflows.post_process_metadata" in query for query, _params in connection.queries)
+
+
+def test_ranker_claim_rejects_targets_ranked_after_the_worker_loaded_them():
+    connection = RankerClaimConnection(active_ranker=None, eligible_targets=0)
+
+    assert claim_ranker(Database(""), connection) is None
+    eligibility_query = next(
+        query for query, _params in connection.queries if "FROM workflows.vulnerabilities" in query
+    )
+    assert "dedupe_is_canonical = true AND bounty_rank IS NULL" in eligibility_query
+    assert not any("INSERT INTO workflows.post_process_metadata" in query for query, _params in connection.queries)

--- a/engine/tests/test_security_hardening.py
+++ b/engine/tests/test_security_hardening.py
@@ -130,6 +130,31 @@ def test_scan_runner_startup_rejects_missing_runner_image(monkeypatch, tmp_path)
     assert exc_info.value.code == "configuration_error"
 
 
+def test_snapshot_scan_runner_uses_image_workspace_without_host_workspace_mount(monkeypatch, tmp_path):
+    data_dir = tmp_path / "engine-data"
+    host_data_dir = tmp_path / "host-engine-data"
+    repo_dir = data_dir / "jobs" / "metadata-777" / "workspace"
+    home_dir = data_dir / "jobs" / "metadata-777" / "home"
+    repo_dir.mkdir(parents=True)
+    home_dir.mkdir(parents=True)
+    monkeypatch.setenv("ENGINE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("ENGINE_DOCKER_DATA_DIR_HOST", str(host_data_dir))
+    monkeypatch.setattr(harnesses.shutil, "which", lambda name: "docker" if name == "docker" else None)
+
+    command = REAL_SCAN_DOCKER_COMMAND(
+        ["codex", "exec", "-"],
+        str(repo_dir),
+        {"HOME": str(home_dir)},
+        runner_image="open-kritt-workspace-snapshot:test",
+    )
+
+    mounts = [command[index + 1] for index, value in enumerate(command) if value == "--mount"]
+    assert f"type=bind,src={host_data_dir / 'jobs' / 'metadata-777' / 'home'},dst=/home/runner" in mounts
+    assert not any("dst=/workspace" in mount for mount in mounts)
+    assert "open-kritt-workspace-snapshot:test" in command
+    assert command[command.index("open-kritt-workspace-snapshot:test") + 1 :][:2] == ["codex", "exec"]
+
+
 def test_prewarm_rebuilds_previous_marker_version_instead_of_promoting_it(monkeypatch, tmp_path):
     stale_base = tmp_path / "cache" / "owner__repo@HEAD"
     stale_repo = stale_base / "owner__repo"

--- a/engine/tests/test_worker_backoff.py
+++ b/engine/tests/test_worker_backoff.py
@@ -610,6 +610,44 @@ def test_fair_scheduler_honors_a_hard_per_scan_worker_cap():
     assert worker._reserve_scan() is None
 
 
+def test_fair_scheduler_lends_unused_workers_to_a_scan_that_can_claim_work(monkeypatch):
+    scans = [{"id": 1, "inserted_at": "1"}, {"id": 2, "inserted_at": "2"}]
+    worker = _pool_worker(worker_count=6, max_per_scan=0, scans=scans)
+    worker.config.poll_seconds = 5
+    monkeypatch.setattr(worker_module.time, "monotonic", lambda: 100.0)
+
+    first = worker._reserve_scan()
+    second = worker._reserve_scan()
+    worker._record_scan_claim_result(second["id"], did_work=False)
+    worker._release_scan(second["id"])
+    borrowed = [worker._reserve_scan()["id"] for _ in range(5)]
+
+    assert first["id"] == 1
+    assert second["id"] == 2
+    assert borrowed == [1, 1, 1, 1, 1]
+    assert worker._reserve_scan() is None
+
+
+def test_fair_scheduler_retries_a_scan_after_its_no_work_cooldown(monkeypatch):
+    scans = [{"id": 1, "inserted_at": "1"}, {"id": 2, "inserted_at": "2"}]
+    worker = _pool_worker(worker_count=2, max_per_scan=0, scans=scans)
+    worker.config.poll_seconds = 5
+    clock = [100.0]
+    monkeypatch.setattr(worker_module.time, "monotonic", lambda: clock[0])
+
+    first = worker._reserve_scan()
+    second = worker._reserve_scan()
+    worker._record_scan_claim_result(second["id"], did_work=False)
+    worker._release_scan(second["id"])
+    clock[0] += 5
+
+    retried = worker._reserve_scan()
+
+    assert first["id"] == 1
+    assert second["id"] == 2
+    assert retried["id"] == 2
+
+
 def test_fair_scheduler_honors_a_scan_specific_provider_capacity_cap():
     scans = [
         {

--- a/engine/tests/test_workspace_snapshots.py
+++ b/engine/tests/test_workspace_snapshots.py
@@ -1,0 +1,38 @@
+from subprocess import CompletedProcess
+
+import open_kritt_engine.workspace_snapshots as workspace_snapshots
+from open_kritt_engine.workspace_snapshots import workspace_snapshot_image_name, workspace_snapshot_key
+
+
+def test_workspace_snapshot_key_is_stable_and_tracks_image_checkout_and_manifest():
+    arguments = {
+        "base_image_id": "sha256:base",
+        "checkout_key": '{"repo":"owner/repo","commit":"abc"}',
+        "manifest_json": '{"primary":{"path":"/workspace"}}',
+    }
+
+    first = workspace_snapshot_key(**arguments)
+    assert first == workspace_snapshot_key(**arguments)
+    assert first != workspace_snapshot_key(**{**arguments, "base_image_id": "sha256:other"})
+    assert first != workspace_snapshot_key(**{**arguments, "checkout_key": '{"commit":"def"}'})
+    assert first != workspace_snapshot_key(**{**arguments, "manifest_json": '{"dependencies":[]}'})
+    assert workspace_snapshot_image_name(first).startswith("open-kritt-workspace-snapshot:")
+
+
+def test_cleanup_stale_builders_preserves_snapshot_leases(monkeypatch):
+    calls = []
+
+    def fake_run(arguments, **_kwargs):
+        calls.append(arguments)
+        if arguments[:2] == ["ps", "--all"]:
+            return CompletedProcess(arguments, 0, stdout="builder-id\nlease-id\n", stderr="")
+        if arguments[-1] == "lease-id" and arguments[:2] == ["container", "inspect"]:
+            return CompletedProcess(arguments, 0, stdout="1\n", stderr="")
+        return CompletedProcess(arguments, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(workspace_snapshots, "_run_docker", fake_run)
+
+    workspace_snapshots.cleanup_stale_workspace_snapshot_builders()
+
+    removed = [arguments[-1] for arguments in calls if arguments[:2] == ["rm", "--force"]]
+    assert removed == ["builder-id"]

--- a/executor-view/server.py
+++ b/executor-view/server.py
@@ -115,6 +115,12 @@ CODEX_HOME_RAW = os.getenv(
 CLAUDE_HOME_RAW = os.getenv(
     "EXECUTOR_VIEW_CLAUDE_HOME", os.getenv("CLAUDE_HOME", "/root/.claude")
 )
+CLAUDE_ACCOUNTS_ROOT = Path(
+    os.getenv("EXECUTOR_VIEW_CLAUDE_ACCOUNTS_ROOT", "/claude-accounts")
+).expanduser()
+CLAUDE_PRIMARY_HOME = Path(
+    os.getenv("EXECUTOR_VIEW_CLAUDE_PRIMARY_HOME", "/root/.claude")
+).expanduser()
 CODEX_ACCOUNTS_ROOT = Path(
     os.getenv("EXECUTOR_VIEW_CODEX_ACCOUNTS_ROOT", "/codex-accounts")
 ).expanduser()
@@ -201,7 +207,7 @@ RECENT_ATTEMPT_LIMIT = int(
 )
 CODEX_ACCOUNT_CACHE = {"expires_at": 0.0, "data": None}
 CODEX_USAGE_CACHE = {}
-CLAUDE_USAGE_CACHE = {"expires_at": 0.0, "credential": None, "data": None}
+CLAUDE_USAGE_CACHE = {}
 OPENROUTER_KEY_CACHE = {"expires_at": 0.0, "credential": None, "data": None}
 ACCOUNT_OVERVIEW_CACHE = {"expires_at": 0.0, "data": None}
 SCAN_STATUS_ACTIONS = {"pause": "paused", "resume": "running", "start": "running"}
@@ -382,7 +388,11 @@ def scan_model_configuration(scan, depth=None):
     overrides = scan.get("model_overrides")
     if overrides is None:
         overrides = scan.get("modelOverrides")
-    override = overrides.get(str(depth)) if depth is not None and isinstance(overrides, dict) else None
+    override = (
+        overrides.get(str(depth))
+        if depth is not None and isinstance(overrides, dict)
+        else None
+    )
     if not isinstance(override, dict):
         return default
     return {
@@ -1084,6 +1094,13 @@ def current_codex_home_raw():
     return CODEX_HOME_RAW
 
 
+def current_claude_home_raw():
+    runtime_config = read_runtime_config()
+    if "ENGINE_CLAUDE_HOME" in runtime_config:
+        return runtime_config["ENGINE_CLAUDE_HOME"]
+    return CLAUDE_HOME_RAW
+
+
 def current_worker_count():
     raw = (
         read_runtime_config().get("ENGINE_WORKER_COUNT")
@@ -1129,6 +1146,18 @@ def configured_codex_homes():
             if key not in seen:
                 seen.add(key)
                 homes.append(candidate)
+    return homes
+
+
+def configured_claude_homes():
+    seen = set()
+    homes = []
+    for raw_path in split_home_list(current_claude_home_raw()):
+        home = Path(raw_path).expanduser()
+        key = str(home)
+        if key not in seen:
+            seen.add(key)
+            homes.append(home)
     return homes
 
 
@@ -1272,7 +1301,7 @@ def build_account_overview(codex, claude, openrouter, fetched=True):
 def empty_claude_accounts():
     return {
         "generatedAt": datetime.now(timezone.utc),
-        "configuredRaw": CLAUDE_HOME_RAW,
+        "configuredRaw": current_claude_home_raw(),
         "active": 0,
         "total": 0,
         "limited": 0,
@@ -1282,8 +1311,29 @@ def empty_claude_accounts():
 
 
 def fetch_claude_accounts(force=False):
-    home = Path(CLAUDE_HOME_RAW).expanduser()
     api_key = configured_secret("ANTHROPIC_API_KEY")
+    homes = configured_claude_homes()
+    if api_key and not homes:
+        homes = [CLAUDE_PRIMARY_HOME]
+    accounts = [
+        claude_account(home, api_key=api_key if index == 0 else "", force=force)
+        for index, home in enumerate(homes)
+    ]
+    active = sum(1 for account in accounts if account["active"])
+    limited = sum(1 for account in accounts if account["statusKind"] == "limited")
+    stale = sum(1 for account in accounts if account["statusKind"] == "stale")
+    return {
+        "generatedAt": datetime.now(timezone.utc),
+        "configuredRaw": current_claude_home_raw(),
+        "active": active,
+        "total": len(accounts),
+        "limited": limited,
+        "stale": stale,
+        "accounts": accounts,
+    }
+
+
+def claude_account(home, api_key="", force=False):
     auth = load_claude_auth(home)
     oauth = load_claude_oauth(home)
     usage = claude_usage_for_account(oauth.get("accessToken"), force=force)
@@ -1366,37 +1416,49 @@ def fetch_claude_accounts(force=False):
     if auth_error:
         add_detail(details, "Authentication", auth_error)
 
-    account = {
-        "id": "default",
+    account_id = removable_claude_account_id(home)
+    return {
+        "id": account_id,
         "provider": "Claude",
-        "label": auth.get("email") or auth.get("name") or "Claude Code",
+        "label": auth.get("email") or auth.get("name") or claude_account_label(home),
         "path": str(home),
         "email": auth.get("email"),
         "name": auth.get("name"),
         "plan": auth.get("subscriptionType") or oauth.get("subscriptionType"),
         "active": active,
-        "canRemove": bool(auth.get("credentialSources")),
+        "canRemove": bool(account_id and auth.get("credentialSources")),
         "status": status,
         "statusKind": status_kind,
         "authError": auth_error,
         "details": details,
         "rateLimits": rate_limits,
     }
-    return {
-        "generatedAt": datetime.now(timezone.utc),
-        "configuredRaw": CLAUDE_HOME_RAW,
-        "active": 1 if active else 0,
-        "total": 1 if active else 0,
-        "limited": 1 if limited else 0,
-        "stale": 1 if stale else 0,
-        "accounts": [account],
-    }
+
+
+def removable_claude_account_id(home):
+    if home in {CLAUDE_PRIMARY_HOME, Path(CLAUDE_HOME_RAW).expanduser()}:
+        return "default"
+    try:
+        relative = home.relative_to(CLAUDE_ACCOUNTS_ROOT)
+    except ValueError:
+        return None
+    if len(relative.parts) != 2 or relative.parts[1] != ".claude":
+        return None
+    account_id = relative.parts[0]
+    if not ACCOUNT_ID_PATTERN.fullmatch(account_id):
+        return None
+    return account_id
+
+
+def claude_account_label(home):
+    return home.parent.name if home.name == ".claude" else home.name
 
 
 def load_claude_auth(home):
     candidates = [
         home / ".credentials.json",
         home / "credentials.json",
+        home / ".open-kritt-account.json",
         home / ".claude.json",
         home / "settings.json",
         home / "claude.json",
@@ -1427,7 +1489,9 @@ def load_claude_auth(home):
         "sources": profile_sources,
         "credentialSources": credential_sources,
         "profileSources": profile_sources,
-        "email": first_json_value(parsed, {"email", "user_email", "account_email"}),
+        "email": first_json_value(
+            parsed, {"email", "emailaddress", "user_email", "account_email"}
+        ),
         "name": first_json_value(parsed, {"name", "username", "display_name"}),
         "organization": first_json_value(
             parsed,
@@ -1532,12 +1596,9 @@ def claude_usage_for_account(access_token, force=False):
         return None
     now = time.monotonic()
     credential = secret_fingerprint(access_token)
-    cached = (
-        CLAUDE_USAGE_CACHE.get("data")
-        if CLAUDE_USAGE_CACHE.get("credential") == credential
-        else None
-    )
-    if cached and now < CLAUDE_USAGE_CACHE.get("expires_at", 0):
+    cache_entry = claude_usage_cache_entry(credential)
+    cached = cache_entry.get("data")
+    if cached and now < cache_entry.get("expires_at", 0):
         return cached
     if not force:
         if cached:
@@ -1549,9 +1610,7 @@ def claude_usage_for_account(access_token, force=False):
     result = fetch_claude_usage(access_token)
     if result.get("primary") or result.get("secondary"):
         result["stale"] = False
-        CLAUDE_USAGE_CACHE["data"] = result
-        CLAUDE_USAGE_CACHE["credential"] = credential
-        CLAUDE_USAGE_CACHE["expires_at"] = now + CLAUDE_USAGE_CACHE_SECONDS
+        store_claude_usage_cache(credential, result, now + CLAUDE_USAGE_CACHE_SECONDS)
         return result
     if cached:
         fallback = dict(cached)
@@ -1559,15 +1618,33 @@ def claude_usage_for_account(access_token, force=False):
         fallback["error"] = result.get("error") or "Claude usage check failed"
         fallback["statusCode"] = result.get("statusCode")
         fallback["attemptedAt"] = result.get("checkedAt")
-        CLAUDE_USAGE_CACHE["data"] = fallback
-        CLAUDE_USAGE_CACHE["credential"] = credential
-        CLAUDE_USAGE_CACHE["expires_at"] = now + CLAUDE_USAGE_CACHE_SECONDS
+        store_claude_usage_cache(credential, fallback, now + CLAUDE_USAGE_CACHE_SECONDS)
         return fallback
     result["stale"] = True
-    CLAUDE_USAGE_CACHE["data"] = result
-    CLAUDE_USAGE_CACHE["credential"] = credential
-    CLAUDE_USAGE_CACHE["expires_at"] = now + CLAUDE_USAGE_CACHE_SECONDS
+    store_claude_usage_cache(credential, result, now + CLAUDE_USAGE_CACHE_SECONDS)
     return result
+
+
+def claude_usage_cache_entry(credential):
+    # Accept the pre-multi-account cache shape while tests and rolling upgrades
+    # may still have it in memory.
+    if "credential" in CLAUDE_USAGE_CACHE:
+        return (
+            CLAUDE_USAGE_CACHE
+            if CLAUDE_USAGE_CACHE.get("credential") == credential
+            else {}
+        )
+    entry = CLAUDE_USAGE_CACHE.get(credential)
+    return entry if isinstance(entry, dict) else {}
+
+
+def store_claude_usage_cache(credential, data, expires_at):
+    entry = {"data": data, "expires_at": expires_at}
+    if "credential" in CLAUDE_USAGE_CACHE:
+        CLAUDE_USAGE_CACHE.update(entry)
+        CLAUDE_USAGE_CACHE["credential"] = credential
+    else:
+        CLAUDE_USAGE_CACHE[credential] = entry
 
 
 def fetch_claude_usage(access_token):

--- a/executor-view/test_server.py
+++ b/executor-view/test_server.py
@@ -76,6 +76,11 @@ def write_claude_credentials(
 
 
 class ExecutorViewSummaryTests(unittest.TestCase):
+    def setUp(self):
+        runtime_config = patch.object(server, "read_runtime_config", return_value={})
+        runtime_config.start()
+        self.addCleanup(runtime_config.stop)
+
     def test_executor_html_has_no_accounts_tab(self):
         self.assertNotIn('id="tab-accounts"', server.HTML)
         self.assertNotIn("renderAccounts", server.HTML)
@@ -118,7 +123,9 @@ class ExecutorViewSummaryTests(unittest.TestCase):
         self.assertEqual(job["model"], "claude-sonnet")
         self.assertEqual(job["modelProvider"], "claude")
         self.assertEqual(job["harness"], "claude-code")
-        self.assertEqual(server.scan_model_configuration(scan, 0)["model"], "gpt-5-codex")
+        self.assertEqual(
+            server.scan_model_configuration(scan, 0)["model"], "gpt-5-codex"
+        )
 
     def test_public_bind_requires_auth_even_for_a_loopback_host_header(self):
         self.assertTrue(server.bind_address_is_loopback("localhost"))
@@ -338,6 +345,33 @@ class ExecutorViewSummaryTests(unittest.TestCase):
         ):
             self.assertEqual(server.current_codex_home_raw(), "")
             self.assertEqual(server.configured_codex_homes(), [])
+
+    def test_claude_homes_follow_live_runtime_changes_without_restart(self):
+        runtime = {"ENGINE_CLAUDE_HOME": "/root/.claude"}
+        with patch.object(
+            server, "read_runtime_config", side_effect=lambda: dict(runtime)
+        ):
+            self.assertEqual(
+                server.configured_claude_homes(),
+                [Path("/root/.claude")],
+            )
+
+            runtime["ENGINE_CLAUDE_HOME"] = (
+                "/root/.claude,/claude-accounts/reviewer/.claude"
+            )
+            self.assertEqual(
+                server.configured_claude_homes(),
+                [
+                    Path("/root/.claude"),
+                    Path("/claude-accounts/reviewer/.claude"),
+                ],
+            )
+
+            runtime["ENGINE_CLAUDE_HOME"] = "/claude-accounts/reviewer/.claude"
+            self.assertEqual(
+                server.configured_claude_homes(),
+                [Path("/claude-accounts/reviewer/.claude")],
+            )
 
     def test_scan_summary_reports_total_and_visible_window(self):
         summary = server.summarize_scan_counts(
@@ -792,6 +826,8 @@ class ExecutorViewSummaryTests(unittest.TestCase):
 
             self.assertEqual(account["active"], 0)
             self.assertEqual(account["accounts"][0]["id"], "default")
+            self.assertEqual(account["accounts"][0]["email"], "researcher@example.test")
+            self.assertEqual(account["accounts"][0]["label"], "researcher@example.test")
             self.assertFalse(account["accounts"][0]["canRemove"])
             self.assertEqual(
                 account["accounts"][0]["status"], "profile found; login required"
@@ -810,6 +846,51 @@ class ExecutorViewSummaryTests(unittest.TestCase):
             self.assertEqual(account["active"], 1)
             self.assertEqual(account["accounts"][0]["status"], "logged in")
             self.assertTrue(account["accounts"][0]["canRemove"])
+
+    def test_multiple_claude_homes_are_reported_as_distinct_removable_accounts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            accounts_root = Path(directory) / "claude-accounts"
+            reviewer = accounts_root / "reviewer" / ".claude"
+            researcher = accounts_root / "researcher" / ".claude"
+            reviewer.mkdir(parents=True)
+            researcher.mkdir(parents=True)
+            write_claude_credentials(reviewer, access_token="reviewer-token")
+            write_claude_credentials(researcher, access_token="researcher-token")
+            server.CLAUDE_USAGE_CACHE = {}
+            with (
+                patch.object(server, "CLAUDE_ACCOUNTS_ROOT", accounts_root),
+                patch.object(
+                    server,
+                    "configured_claude_homes",
+                    return_value=[reviewer, researcher],
+                ),
+                patch.object(server, "current_claude_home_raw", return_value="managed"),
+                patch.object(server, "configured_secret", return_value=""),
+                patch.object(
+                    server,
+                    "fetch_claude_usage",
+                    side_effect=lambda token: claude_usage(
+                        primary=10 if token == "reviewer-token" else 20
+                    ),
+                ),
+            ):
+                result = server.fetch_claude_accounts(force=True)
+
+        self.assertEqual(result["active"], 2)
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(
+            [account["id"] for account in result["accounts"]],
+            ["reviewer", "researcher"],
+        )
+        self.assertTrue(all(account["canRemove"] for account in result["accounts"]))
+        self.assertEqual(
+            [
+                account["rateLimits"]["primary"]["usedPercent"]
+                for account in result["accounts"]
+            ],
+            [10, 20],
+        )
+        self.assertEqual(len(server.CLAUDE_USAGE_CACHE), 2)
 
     def test_claude_usage_is_normalized_without_exposing_oauth_tokens(self):
         class Response:

--- a/frontend/src/components/WorkflowModelConfiguration.jsx
+++ b/frontend/src/components/WorkflowModelConfiguration.jsx
@@ -1,4 +1,9 @@
-import ModelConfiguration, { modelConfigurationForCatalog, modelConfigurationIsValid } from './ModelConfiguration.jsx';
+import ModelConfiguration, {
+  THINKING_EFFORTS,
+  modelConfigurationForCatalog,
+  modelConfigurationIsValid,
+} from './ModelConfiguration.jsx';
+import { thinkingEffortForModelChange, thinkingEffortsForModel } from '../lib/modelProviders.js';
 import {
   enableModelOverrides,
   modelOverridesDraft,
@@ -9,8 +14,19 @@ import {
 
 export function workflowModelConfigurationForCatalog(current, providers, catalog) {
   const base = modelConfigurationForCatalog(current, providers, catalog);
+  const postProcessingEfforts = thinkingEffortsForModel(
+    catalog,
+    base.model_provider,
+    base.model,
+    THINKING_EFFORTS,
+    base.harness
+  );
   return {
     ...base,
+    post_processing_thinking_effort: thinkingEffortForModelChange(
+      current?.post_processing_thinking_effort ?? current?.postProcessingThinkingEffort ?? base.thinking_effort,
+      postProcessingEfforts
+    ),
     model_overrides: normalizeModelOverrides(current?.model_overrides ?? current?.modelOverrides, (configuration) =>
       modelConfigurationForCatalog(configuration, providers, catalog)
     ),
@@ -19,6 +35,16 @@ export function workflowModelConfigurationForCatalog(current, providers, catalog
 
 export function workflowModelConfigurationIsValid(value, depths, providers, catalog) {
   if (!modelConfigurationIsValid(value, providers, catalog)) return false;
+  const postProcessingEfforts = thinkingEffortsForModel(
+    catalog,
+    value.model_provider,
+    value.model,
+    THINKING_EFFORTS,
+    value.harness
+  );
+  const postProcessingThinkingEffort =
+    value?.post_processing_thinking_effort ?? value?.postProcessingThinkingEffort ?? value?.thinking_effort;
+  if (!postProcessingEfforts.includes(postProcessingThinkingEffort)) return false;
   const overrides = modelOverridesDraft(value?.model_overrides ?? value?.modelOverrides);
   const allowedDepths = new Set(depths.map(String));
   if (Object.keys(overrides).some((depth) => !allowedDepths.has(depth))) return false;
@@ -55,6 +81,15 @@ export default function WorkflowModelConfiguration({
   const customized = Object.keys(overrides).length > 0;
   const canCustomize = depths.length > 0;
   const depthLabels = new Map(depthChips.map((chip) => [chip.depth, chip]));
+  const postProcessingEfforts = thinkingEffortsForModel(
+    catalog,
+    value.model_provider,
+    value.model,
+    THINKING_EFFORTS,
+    value.harness
+  );
+  const postProcessingThinkingEffort =
+    value?.post_processing_thinking_effort ?? value?.postProcessingThinkingEffort ?? value?.thinking_effort;
 
   const useSingleModel = () => onChange({ ...value, model_overrides: {} });
   const customizeByDepth = () =>
@@ -100,7 +135,7 @@ export default function WorkflowModelConfiguration({
       >
         {customized && (
           <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginBottom: 9 }}>
-            DEFAULT &amp; POST-PROCESSING
+            DEFAULT WORKFLOW MODEL
           </div>
         )}
         <ModelConfiguration
@@ -112,6 +147,43 @@ export default function WorkflowModelConfiguration({
           disabled={disabled}
         />
       </div>
+
+      <label
+        style={{
+          display: 'block',
+          maxWidth: 280,
+          marginTop: 12,
+          border: '1px solid var(--border)',
+          borderRadius: 9,
+          padding: 13,
+          background: 'var(--surface-2)',
+        }}
+      >
+        <span className="mono" style={{ display: 'block', fontSize: 10.5, color: 'var(--text-3)', marginBottom: 7 }}>
+          POST-PROCESSING THINKING EFFORT
+        </span>
+        <select
+          className="mono"
+          value={postProcessingThinkingEffort}
+          disabled={disabled || postProcessingEfforts.length === 0}
+          onChange={(event) => onChange({ ...value, post_processing_thinking_effort: event.target.value })}
+          style={{
+            width: '100%',
+            height: 36,
+            padding: '0 10px',
+            borderRadius: 7,
+            border: '1px solid var(--border)',
+            background: 'var(--surface)',
+            color: 'var(--text)',
+          }}
+        >
+          {postProcessingEfforts.map((effort) => (
+            <option key={effort} value={effort}>
+              {effort}
+            </option>
+          ))}
+        </select>
+      </label>
 
       {customized && (
         <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>

--- a/frontend/src/components/WorkflowModelConfiguration.test.jsx
+++ b/frontend/src/components/WorkflowModelConfiguration.test.jsx
@@ -34,6 +34,7 @@ const configured = {
   model_provider: 'codex',
   harness: 'codex',
   thinking_effort: 'high',
+  post_processing_thinking_effort: 'high',
   model_overrides: {
     0: {
       model: 'gpt-5-codex',
@@ -95,7 +96,8 @@ describe('WorkflowModelConfiguration', () => {
 
     expect(html).toContain('One model for all depths');
     expect(html).toContain('Customize by depth');
-    expect(html).toContain('DEFAULT &amp; POST-PROCESSING');
+    expect(html).toContain('DEFAULT WORKFLOW MODEL');
+    expect(html).toContain('POST-PROCESSING THINKING EFFORT');
     expect(html).toContain('DEPTH 0');
     expect(html).toContain('DEPTH 1');
     expect(html).toContain('2 steps');

--- a/frontend/src/lib/scanDuplication.js
+++ b/frontend/src/lib/scanDuplication.js
@@ -1,6 +1,13 @@
 import { modelOverridesDraft } from './modelOverrides.js';
 
-const CONFIGURATION_RELATION_KEYS = ['post_script_ids', 'post_scripts', 'agent_skill_ids', 'agent_skills'];
+const CONFIGURATION_RELATION_KEYS = [
+  'post_script_ids',
+  'post_scripts',
+  'agent_skill_ids',
+  'agent_skills',
+  'post_processing_thinking_effort',
+  'postProcessingThinkingEffort',
+];
 
 function uniqueIds(values) {
   return [...new Set(values.map((value) => `${value ?? ''}`.trim()).filter(Boolean))];
@@ -68,6 +75,7 @@ export function scanConfigurationDraft(scan) {
     model_provider: `${scan.modelProvider ?? ''}`,
     harness: `${scan.harness ?? ''}`,
     thinking_effort: `${scan.thinkingEffort ?? ''}`,
+    post_processing_thinking_effort: `${scan.postProcessingThinkingEffort ?? scan.thinkingEffort ?? ''}`,
     model_overrides: modelOverridesDraft(scan.modelOverrides),
     extra: duplicateExtra(scan.extra),
     // Scan records store only the effective combined ranker text, not the

--- a/frontend/src/lib/scanDuplication.test.js
+++ b/frontend/src/lib/scanDuplication.test.js
@@ -25,11 +25,13 @@ describe('scanConfigurationDraft', () => {
         include_tests: true,
         post_script_ids: ['21', '22'],
         agent_skill_ids: ['31', '32'],
+        post_processing_thinking_effort: 'medium',
       },
       model: 'gpt-5.4',
       modelProvider: 'codex',
       harness: 'codex',
       thinkingEffort: 'high',
+      postProcessingThinkingEffort: 'medium',
       modelOverrides: {
         1: {
           model: 'claude-sonnet',
@@ -68,6 +70,7 @@ describe('scanConfigurationDraft', () => {
       model_provider: 'codex',
       harness: 'codex',
       thinking_effort: 'high',
+      post_processing_thinking_effort: 'medium',
       model_overrides: {
         1: {
           model: 'claude-sonnet',

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -118,7 +118,7 @@ export default function Accounts() {
     const impact =
       provider.id === 'codex'
         ? 'This signs Codex out locally and removes its managed account home when applicable. Existing scans and results are kept.'
-        : 'This signs Claude out locally. Existing scans and results are kept.';
+        : 'This signs Claude out locally and removes its managed account home when applicable. Existing scans and results are kept.';
     if (!window.confirm(`Remove ${label}?\n\n${impact}`)) return;
     const key = `${provider.id}:${account.id}`;
     const previous = data;
@@ -355,7 +355,7 @@ export function providerActionLabel(provider) {
   const signInRequired = provider.accounts.some((account) => account.statusKind === 'expired');
   if (provider.id === 'codex') return signInRequired ? 'Sign in to Codex again' : 'Add Codex account';
   if (signInRequired) return 'Sign in to Claude again';
-  return provider.configured ? 'Reconnect Claude' : 'Sign in to Claude';
+  return 'Add Claude account';
 }
 
 export function providerReloginAccountId(provider) {
@@ -844,7 +844,7 @@ function LoginDialog({ provider, onClose, onComplete }) {
                 ? `Sign in to ${provider.label} again`
                 : provider.id === 'codex'
                   ? 'Add Codex account'
-                  : 'Sign in to Claude'}
+                  : 'Add Claude account'}
             </div>
           </div>
           <button className="account-dialog-close" type="button" aria-label="Close" onClick={cancel}>
@@ -862,7 +862,7 @@ function LoginDialog({ provider, onClose, onComplete }) {
             ) : (
               <>
                 Claude will open its subscription sign-in page. After authentication, copy the callback code into this
-                dialog to {relogin ? 'replace the expired login on this account' : 'finish linking Claude Code'}.
+                dialog to {relogin ? 'replace the expired login on this account' : 'add this Claude account'}.
               </>
             )}
           </div>

--- a/frontend/src/pages/Accounts.test.js
+++ b/frontend/src/pages/Accounts.test.js
@@ -77,6 +77,27 @@ describe('Claude usage bars', () => {
   });
 });
 
+describe('multiple Claude accounts', () => {
+  it('offers another account instead of reconnecting the configured provider', () => {
+    expect(
+      providerActionLabel({
+        id: 'claude',
+        management: 'login',
+        configured: true,
+        accounts: [{ id: 'default', statusKind: 'available' }],
+      })
+    ).toBe('Add Claude account');
+    expect(
+      providerActionLabel({
+        id: 'claude',
+        management: 'login',
+        configured: false,
+        accounts: [],
+      })
+    ).toBe('Add Claude account');
+  });
+});
+
 describe('expired Claude login', () => {
   it('shows the provider authentication error and a same-account login action', () => {
     const html = renderToStaticMarkup(

--- a/frontend/src/pages/CreateScan.jsx
+++ b/frontend/src/pages/CreateScan.jsx
@@ -99,6 +99,7 @@ export default function CreateScan() {
     model_provider: '',
     harness: '',
     thinking_effort: 'medium',
+    post_processing_thinking_effort: 'medium',
     model_overrides: {},
     extra: {},
     rankerIds: [],
@@ -321,6 +322,7 @@ export default function CreateScan() {
         normalized.model === f.model &&
         normalized.model_provider === f.model_provider &&
         normalized.thinking_effort === f.thinking_effort &&
+        normalized.post_processing_thinking_effort === f.post_processing_thinking_effort &&
         normalized.harness === f.harness &&
         modelOverridesEqual(normalized.model_overrides, f.model_overrides)
       )
@@ -519,6 +521,7 @@ export default function CreateScan() {
       model_provider: form.model_provider,
       harness: form.harness,
       thinking_effort: form.thinking_effort,
+      post_processing_thinking_effort: form.post_processing_thinking_effort,
       model_overrides: form.model_overrides,
       severity_ranker: combinedRanker,
       extra: form.extra,

--- a/frontend/src/pages/ScanDetail.jsx
+++ b/frontend/src/pages/ScanDetail.jsx
@@ -1070,6 +1070,7 @@ function ScanRunSettings({
           <RuntimeSetting label="model" value={current.model} />
           <RuntimeSetting label="model_provider" value={current.model_provider || '—'} />
           <RuntimeSetting label="thinking_effort" value={current.thinking_effort || '—'} />
+          <RuntimeSetting label="post-processing effort" value={current.post_processing_thinking_effort || '—'} />
           <RuntimeSetting label="harness" value={current.harness} />
           <RuntimeSetting label="depth overrides" value={Object.keys(current.model_overrides).length || 'none'} />
           <RuntimeSetting
@@ -1087,6 +1088,7 @@ export function runSettingsDraft(scan = {}) {
     model: scan.model || '',
     model_provider: scan.modelProvider || 'openrouter',
     thinking_effort: scan.thinkingEffort || 'medium',
+    post_processing_thinking_effort: scan.postProcessingThinkingEffort || scan.thinkingEffort || 'medium',
     harness: scan.harness || 'codex',
     model_overrides: modelOverridesDraft(scan.modelOverrides),
     job_limit: scan.jobLimit == null ? '' : `${scan.jobLimit}`,
@@ -1105,6 +1107,10 @@ export function mergeRunSettingsDraft(current = {}, patch = {}) {
     model: runSettingsValue(current?.model, ''),
     model_provider: runSettingsValue(current?.model_provider, 'openrouter'),
     thinking_effort: runSettingsValue(current?.thinking_effort, 'medium'),
+    post_processing_thinking_effort: runSettingsValue(
+      current?.post_processing_thinking_effort,
+      current?.thinking_effort || 'medium'
+    ),
     harness: runSettingsValue(current?.harness, 'codex'),
     model_overrides: modelOverridesDraft(current?.model_overrides),
     job_limit: runSettingsValue(current?.job_limit, ''),
@@ -1113,6 +1119,10 @@ export function mergeRunSettingsDraft(current = {}, patch = {}) {
     model: runSettingsValue(patch?.model, base.model),
     model_provider: runSettingsValue(patch?.model_provider, base.model_provider),
     thinking_effort: runSettingsValue(patch?.thinking_effort, base.thinking_effort),
+    post_processing_thinking_effort: runSettingsValue(
+      patch?.post_processing_thinking_effort,
+      base.post_processing_thinking_effort
+    ),
     harness: runSettingsValue(patch?.harness, base.harness),
     model_overrides: hasModelOverrides ? modelOverridesDraft(patch.model_overrides) : base.model_overrides,
     job_limit: runSettingsValue(patch?.job_limit, base.job_limit),
@@ -1130,6 +1140,8 @@ export function runSettingsPayload(draft, current) {
     payload.model_provider = normalizedDraft.model_provider;
   if (normalizedDraft.thinking_effort !== normalizedCurrent.thinking_effort)
     payload.thinking_effort = normalizedDraft.thinking_effort;
+  if (normalizedDraft.post_processing_thinking_effort !== normalizedCurrent.post_processing_thinking_effort)
+    payload.post_processing_thinking_effort = normalizedDraft.post_processing_thinking_effort;
   if (normalizedDraft.harness !== normalizedCurrent.harness) payload.harness = normalizedDraft.harness;
   if (!modelOverridesEqual(normalizedDraft.model_overrides, normalizedCurrent.model_overrides))
     payload.model_overrides = normalizedDraft.model_overrides;

--- a/frontend/src/pages/ScanDetail.test.jsx
+++ b/frontend/src/pages/ScanDetail.test.jsx
@@ -42,6 +42,7 @@ describe('scan run settings', () => {
     model: 'gpt-5-codex',
     model_provider: 'codex',
     thinking_effort: 'medium',
+    post_processing_thinking_effort: 'low',
     harness: 'codex',
     model_overrides: {},
     job_limit: '250',
@@ -52,6 +53,7 @@ describe('scan run settings', () => {
       model: 'gpt-5-codex',
       model_provider: 'codex',
       thinking_effort: 'medium',
+      post_processing_thinking_effort: 'low',
       harness: 'codex',
     };
 
@@ -64,6 +66,7 @@ describe('scan run settings', () => {
       model: 'legacy-model',
       model_provider: 'openrouter',
       thinking_effort: 'medium',
+      post_processing_thinking_effort: 'medium',
       harness: 'codex',
       model_overrides: {},
       job_limit: '',
@@ -77,6 +80,12 @@ describe('scan run settings', () => {
   it('still supports setting and clearing a job limit', () => {
     expect(runSettingsPayload({ job_limit: ' 25 ' }, { ...current, job_limit: '' })).toEqual({ jobLimit: 25 });
     expect(runSettingsPayload({ job_limit: '' }, current)).toEqual({ jobLimit: null });
+  });
+
+  it('updates post-processing effort independently', () => {
+    expect(runSettingsPayload({ post_processing_thinking_effort: 'medium' }, current)).toEqual({
+      post_processing_thinking_effort: 'medium',
+    });
   });
 
   it('replaces or clears normalized workflow-depth model overrides', () => {

--- a/scripts/kritt-lib.mjs
+++ b/scripts/kritt-lib.mjs
@@ -349,15 +349,15 @@ function splitConfiguredHomes(value) {
     .filter(Boolean);
 }
 
-export async function updateRuntimeCodexHome(runtimeConfigPath, home, present, initialHomes = []) {
+async function updateRuntimeProviderHome(runtimeConfigPath, key, home, present, initialHomes = []) {
   let text = '';
   try {
     text = await readFile(runtimeConfigPath, 'utf8');
   } catch (error) {
     if (error?.code !== 'ENOENT') throw error;
-    if (initialHomes.length) text = `ENGINE_CODEX_HOME=${initialHomes.join(',')}\n`;
+    if (initialHomes.length) text = `${key}=${initialHomes.join(',')}\n`;
   }
-  const homes = splitConfiguredHomes(runtimeEnvValue(text, 'ENGINE_CODEX_HOME'));
+  const homes = splitConfiguredHomes(runtimeEnvValue(text, key));
   const nextHomes = present
     ? homes.includes(home)
       ? homes
@@ -366,8 +366,8 @@ export async function updateRuntimeCodexHome(runtimeConfigPath, home, present, i
   if (nextHomes.length === homes.length && nextHomes.every((candidate, index) => candidate === homes[index])) {
     return false;
   }
-  const line = `ENGINE_CODEX_HOME=${nextHomes.join(',')}`;
-  const pattern = /^\s*(?:export\s+)?ENGINE_CODEX_HOME=.*$/m;
+  const line = `${key}=${nextHomes.join(',')}`;
+  const pattern = new RegExp(`^\\s*(?:export\\s+)?${key}=.*$`, 'm');
   const updated = pattern.test(text)
     ? text.replace(pattern, line)
     : `${text}${text && !text.endsWith('\n') ? '\n' : ''}${line}\n`;
@@ -376,12 +376,34 @@ export async function updateRuntimeCodexHome(runtimeConfigPath, home, present, i
   return true;
 }
 
-async function readRuntimeCodexHomes(runtimeConfigPath) {
+export function updateRuntimeCodexHome(runtimeConfigPath, home, present, initialHomes = []) {
+  return updateRuntimeProviderHome(runtimeConfigPath, 'ENGINE_CODEX_HOME', home, present, initialHomes);
+}
+
+export function updateRuntimeClaudeHome(runtimeConfigPath, home, present, initialHomes = []) {
+  return updateRuntimeProviderHome(runtimeConfigPath, 'ENGINE_CLAUDE_HOME', home, present, initialHomes);
+}
+
+async function readRuntimeHomes(runtimeConfigPath) {
   try {
     const text = await readFile(runtimeConfigPath, 'utf8');
-    return { exists: true, homes: splitConfiguredHomes(runtimeEnvValue(text, 'ENGINE_CODEX_HOME')) };
+    return {
+      exists: true,
+      codexDefined: /^\s*(?:export\s+)?ENGINE_CODEX_HOME=/m.test(text),
+      codexHomes: splitConfiguredHomes(runtimeEnvValue(text, 'ENGINE_CODEX_HOME')),
+      claudeDefined: /^\s*(?:export\s+)?ENGINE_CLAUDE_HOME=/m.test(text),
+      claudeHomes: splitConfiguredHomes(runtimeEnvValue(text, 'ENGINE_CLAUDE_HOME')),
+    };
   } catch (error) {
-    if (error?.code === 'ENOENT') return { exists: false, homes: [] };
+    if (error?.code === 'ENOENT') {
+      return {
+        exists: false,
+        codexDefined: false,
+        codexHomes: [],
+        claudeDefined: false,
+        claudeHomes: [],
+      };
+    }
     throw error;
   }
 }
@@ -425,6 +447,19 @@ function configuredCodexHomes(rootDir, values, homeDir) {
   return homes;
 }
 
+function configuredClaudeHomes(primary, accountsRoot, runtimeHomes) {
+  const homes = [];
+  for (const configured of runtimeHomes) {
+    let hostPath = null;
+    if (configured === '/root/.claude') hostPath = primary;
+    else if (configured.startsWith('/claude-accounts/')) {
+      hostPath = resolve(accountsRoot, configured.slice('/claude-accounts/'.length));
+    }
+    if (hostPath && !homes.includes(hostPath)) homes.push(hostPath);
+  }
+  return homes;
+}
+
 export function resolveHomePath(configuredPath, homeDir = homedir()) {
   const rawPath = configuredPath.trim();
   if (rawPath === '~' || rawPath.startsWith('~/')) return resolve(join(homeDir, rawPath.slice(2)));
@@ -452,16 +487,30 @@ export async function getSetupStatus({ rootDir, envFile = join(rootDir, '.env'),
     engineDataDirectory,
     basename(values.ENGINE_RUNTIME_CONFIG_PATH || 'engine-runtime.env')
   );
-  const runtimeRegistry = await readRuntimeCodexHomes(runtimeConfigPath);
-  const configuredValues = runtimeRegistry.exists
-    ? { ...values, ENGINE_CODEX_HOME: runtimeRegistry.homes.join(',') }
-    : values;
+  const runtimeRegistry = await readRuntimeHomes(runtimeConfigPath);
+  const configuredValues =
+    runtimeRegistry.exists && runtimeRegistry.codexDefined
+      ? { ...values, ENGINE_CODEX_HOME: runtimeRegistry.codexHomes.join(',') }
+      : values;
   const codexHomes = configuredCodexHomes(rootDir, configuredValues, homeDir);
   if (!codexHomes.includes(codexHome)) codexHomes.push(codexHome);
-  const runtimeCodexHomes = runtimeRegistry.exists
-    ? runtimeRegistry.homes
-    : splitConfiguredHomes(values.ENGINE_CODEX_HOME || '/root/.codex');
-  const claudeHome = resolveProjectPath(rootDir, values.ENGINE_CLAUDE_HOME || './.data/claude', homeDir);
+  const runtimeCodexHomes =
+    runtimeRegistry.exists && runtimeRegistry.codexDefined
+      ? runtimeRegistry.codexHomes
+      : splitConfiguredHomes(values.ENGINE_CODEX_HOME || '/root/.codex');
+  const claudeHome = resolveProjectPath(
+    rootDir,
+    values.ENGINE_CLAUDE_HOME_HOST || values.ENGINE_CLAUDE_HOME || './.data/claude',
+    homeDir
+  );
+  const claudeAccountsRoot = resolveProjectPath(
+    rootDir,
+    values.ENGINE_CLAUDE_ACCOUNTS_HOST || './.data/claude-accounts',
+    homeDir
+  );
+  const runtimeClaudeHomes =
+    runtimeRegistry.exists && runtimeRegistry.claudeDefined ? runtimeRegistry.claudeHomes : ['/root/.claude'];
+  const claudeHomes = configuredClaudeHomes(claudeHome, claudeAccountsRoot, runtimeClaudeHomes);
   const credentialsDirectory = resolveProjectPath(
     rootDir,
     values.ENGINE_CREDENTIALS_HOST || './.data/engine/credentials',
@@ -484,7 +533,7 @@ export async function getSetupStatus({ rootDir, envFile = join(rootDir, '.env'),
   const codexLoginIssue = codexLoginPresent
     ? null
     : codexAuthInspections.find((inspection) => inspection.issue !== 'missing')?.issue || null;
-  const claudeLoginPresent = await usableClaudeLogin(claudeHome);
+  const claudeLoginPresent = (await Promise.all(claudeHomes.map((home) => usableClaudeLogin(home)))).some(Boolean);
   const managedProviders = Object.keys(managedState.credentials);
   const providerPresent =
     PROVIDER_KEYS.some((key) => valuesPresent[key]) ||
@@ -502,10 +551,13 @@ export async function getSetupStatus({ rootDir, envFile = join(rootDir, '.env'),
     codexLoginPresent,
     primaryCodexLoginPresent,
     claudeHome,
+    claudeAccountsRoot,
+    claudeHomes,
     claudeLoginPresent,
     credentialsPath,
     runtimeConfigPath,
     runtimeCodexHomes,
+    runtimeClaudeHomes,
     runtimeRegistryExists: runtimeRegistry.exists,
     disabledProviders,
     envExists,
@@ -581,6 +633,25 @@ export async function syncCodexLoginStatus({
     envChanged = true;
   }
   return envChanged ? getSetupStatus({ rootDir, envFile, homeDir }) : status;
+}
+
+export async function syncClaudeLoginStatus({
+  rootDir = process.cwd(),
+  envFile = join(rootDir, '.env'),
+  homeDir = homedir(),
+} = {}) {
+  let status = await getSetupStatus({ rootDir, envFile, homeDir });
+  if (!status.envExists || !status.runtimeRegistryExists) return status;
+
+  const primaryPresent = await usableClaudeLogin(status.claudeHome);
+  await updateRuntimeClaudeHome(status.runtimeConfigPath, '/root/.claude', primaryPresent, status.runtimeClaudeHomes);
+  status = await getSetupStatus({ rootDir, envFile, homeDir });
+  return status;
+}
+
+async function syncProviderLoginStatus(context) {
+  await syncCodexLoginStatus(context);
+  return syncClaudeLoginStatus(context);
 }
 
 function renderStatus(status, io) {
@@ -1033,8 +1104,7 @@ async function manageCodexLogin(context) {
       if (result.ok) {
         await syncCodexLoginStatus(context);
         write(io, result.message);
-      }
-      else writeError(io, result.message);
+      } else writeError(io, result.message);
     }
   } else if (action === '4') {
     write(io, itemInfo(CODEX_LOGIN));
@@ -1045,7 +1115,7 @@ async function manageCodexLogin(context) {
 
 async function manageClaudeLogin(context) {
   const { io, prompter } = context;
-  const status = await getSetupStatus(context);
+  const status = await syncClaudeLoginStatus(context);
   write(io, '\nClaude login');
   write(io, '1) Sign in with Docker');
   write(io, '2) Remove the saved login');
@@ -1060,9 +1130,11 @@ async function manageClaudeLogin(context) {
       runner: context.runner,
       home: status.claudeHome,
     });
+    await syncClaudeLoginStatus(context);
   } else if (action === '2') {
     if (await prompter.confirm('Remove the saved Claude login for this project?')) {
       await removeClaudeAuth(status.claudeHome);
+      await syncClaudeLoginStatus(context);
       write(io, 'Saved Claude login removed.');
     }
   } else if (action === '3') {
@@ -1121,7 +1193,7 @@ export async function runSetup(options = {}) {
     await manageEnvironmentItem(context, item);
   }
 
-  const status = await syncCodexLoginStatus(context);
+  const status = await syncProviderLoginStatus(context);
   if (status.providerPresent) write(context.io, 'Setup complete. Run ./kritt start when you are ready.');
   else write(context.io, 'Setup saved. Add one provider key or a Codex or Claude login before running ./kritt start.');
   return 0;
@@ -1134,7 +1206,7 @@ export async function runStart(options = {}) {
     return 1;
   }
 
-  const status = await syncCodexLoginStatus(context);
+  const status = await syncProviderLoginStatus(context);
   if (!status.providerPresent) {
     if (status.codexLoginIssue === 'permission') {
       writeError(context.io, await codexHomePermissionMessage(status.codexHome, context.rootDir));

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -272,6 +272,26 @@ test('setup migrates Codex accounts registered by the UI into .env', async (t) =
   assert.equal(after.codexLoginPresent, true);
 });
 
+test('status discovers Claude accounts registered by the UI through the live runtime registry', async (t) => {
+  const project = await createProject(t);
+  await ensureEnvFile(project);
+  const accountHome = join(project.rootDir, '.data', 'claude-accounts', 'ui-account', '.claude');
+  const runtimeConfigPath = join(project.rootDir, '.data', 'engine', 'engine-runtime.env');
+  await mkdir(accountHome, { recursive: true });
+  await mkdir(dirname(runtimeConfigPath), { recursive: true });
+  await writeFile(
+    join(accountHome, '.credentials.json'),
+    '{"claudeAiOauth":{"accessToken":"test","refreshToken":"refresh","expiresAt":9999999999999}}'
+  );
+  await writeFile(runtimeConfigPath, 'ENGINE_CLAUDE_HOME=/claude-accounts/ui-account/.claude\n');
+
+  const status = await getSetupStatus(project);
+
+  assert.equal(status.claudeLoginPresent, true);
+  assert.equal(status.providerPresent, true);
+  assert.deepEqual(status.claudeHomes, [accountHome]);
+});
+
 test('guided Claude login uses the shared home monitored by Accounts', async (t) => {
   const project = await createProject(t);
   const io = testIo();
@@ -446,10 +466,7 @@ test('guided Docker login copies a host-owned auth file from an isolated contain
   ]);
   assert.match(commands[1].args.at(-1), /open-kritt-codex-login-.*auth\.json$/);
   assert.equal(await readFile(targetPath, 'utf8'), '{"tokens":{"access_token":"test"}}');
-  assert.equal(
-    (await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777,
-    0o700
-  );
+  assert.equal((await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777, 0o700);
   assert.equal((await stat(targetPath)).mode & 0o777, 0o600);
   assert.equal((await getSetupStatus(project)).codexLoginPresent, true);
   assert.equal(parseEnv(await readFile(project.envFile, 'utf8')).CODEX_LOGIN_CONFIGURED, '1');
@@ -564,10 +581,7 @@ test('start blocks GitHub-only configuration and launches Compose with model acc
   assert.deepEqual(commands, [
     { command: 'docker', args: ['compose', 'up', '--build'], options: { cwd: project.rootDir, stdio: 'inherit' } },
   ]);
-  assert.equal(
-    (await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777,
-    0o700
-  );
+  assert.equal((await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777, 0o700);
 });
 
 test('start reports how to repair a Codex home parent left unwritable by Docker', async (t) => {


### PR DESCRIPTION
## Summary

- add managed multi-account Claude login rotation, refresh, removal, and provider attribution
- add independent post-processing thinking effort across the API, UI, and engine
- add optional image-backed scan workspaces with safe fallback and shared setup limits
- improve worker allocation and post-processing concurrency without workflow-specific behavior
- harden live-branch patch-history verification and SQL migration parsing

## Testing

- backend: 153 tests passed
- frontend: 214 tests passed; production build passed
- engine: 292 tests passed
- executor view: 41 tests passed
- CLI: 26 tests passed
- ESLint and Prettier passed for backend and frontend
- Ruff passed for all changed Python files
- Docker Compose configuration validated