### PR TITLE
fix(cli): keep setup menu options visible on short terminals

### DIFF
--- a/scripts/kritt-ui.mjs
+++ b/scripts/kritt-ui.mjs
@@ -126,26 +126,39 @@ export function renderMenuScreen({
   colorEnabled = false,
 }) {
   const innerWidth = Math.max(20, width - 4);
-  const lines = screenHeader({ title, subtitle, width, colorEnabled });
+  const header = screenHeader({ title, subtitle, width, colorEnabled });
 
-  for (const detail of details) {
+  const detailLines = details.map((detail) => {
     const text = typeof detail === 'string' ? detail : detail.text;
     const tone = typeof detail === 'string' ? null : detail.tone;
     const rendered = truncate(text, innerWidth);
-    lines.push(`  ${tone ? color(rendered, ANSI[tone], colorEnabled) : rendered}`);
-  }
-  if (details.length) lines.push('');
+    return `  ${tone ? color(rendered, ANSI[tone], colorEnabled) : rendered}`;
+  });
 
-  for (const [index, option] of options.entries()) {
+  const optionLines = options.map((option, index) => {
     const active = index === selected;
     const marker = active ? '›' : ' ';
     const description = option.description ? `  ${option.description}` : '';
     const text = truncate(`${marker} ${option.label}${description}`, innerWidth);
-    lines.push(`  ${active ? color(text, ANSI.accent, colorEnabled) : text}`);
-  }
+    return `  ${active ? color(text, ANSI.accent, colorEnabled) : text}`;
+  });
 
-  lines.push('');
-  lines.push(`  ${color(truncate(footer, innerWidth), ANSI.dim, colorEnabled)}`);
+  const footerLine = `  ${color(truncate(footer, innerWidth), ANSI.dim, colorEnabled)}`;
+
+  // The options list (with the selection cursor) and the footer are required to
+  // operate the menu and must never be pushed off-screen by a short terminal.
+  // Details are informational status only - the same state is already echoed in
+  // each option's description - so they are the first thing trimmed when space
+  // is tight.
+  const targetRows = Math.max(12, rows || 24);
+  const requiredRows = header.length + optionLines.length + 2; // blank line + footer
+  const detailBudget = Math.max(0, targetRows - requiredRows);
+  const shownDetails = detailLines.slice(0, detailBudget);
+
+  const lines = [...header, ...shownDetails];
+  if (shownDetails.length) lines.push('');
+  lines.push(...optionLines, '', footerLine);
+
   return fillScreen(lines, { rows });
 }
 

--- a/scripts/kritt-ui.test.mjs
+++ b/scripts/kritt-ui.test.mjs
@@ -132,6 +132,41 @@ test('screen renderers fill the requested terminal height and never reveal secre
   assert.match(input, /•+/);
 });
 
+test('menu options and footer stay visible on a short terminal even with many detail lines', () => {
+  const options = [
+    { id: 'codex-login', label: 'Codex login', description: 'recommended - sign in with a device code' },
+    { id: 'claude-login', label: 'Claude login', description: 'sign in with a Claude subscription' },
+    { id: 'CODEX_API_KEY', label: 'Codex API key', description: 'not set' },
+    { id: 'OPENAI_API_KEY', label: 'OpenAI API key', description: 'not set' },
+    { id: 'ANTHROPIC_API_KEY', label: 'Anthropic API key', description: 'not set' },
+    { id: 'OPENROUTER_API_KEY', label: 'OpenRouter API key', description: 'not set' },
+    { id: 'GITHUB_TOKEN', label: 'GitHub token', description: 'optional for private repositories' },
+    { id: 'back', label: 'Back', description: 'Return to the main menu' },
+  ];
+  const details = [
+    '○ Codex login not set (recommended)',
+    '○ Claude login not set',
+    '○ Codex API key not set',
+    '○ OpenAI API key not set',
+    '○ Anthropic API key not set',
+    '○ OpenRouter API key not set',
+    '○ GitHub token not set (optional)',
+  ];
+
+  const screen = renderMenuScreen({
+    title: 'Setup',
+    subtitle: 'Choose one option to configure model access',
+    details,
+    options,
+    selected: 1,
+    rows: 14,
+    width: 90,
+  });
+
+  assert.match(screen, /› Claude login/);
+  for (const option of options) assert.match(screen, new RegExp(option.label));
+});
+
 test('menu details can carry semantic color without changing their text', () => {
   const screen = renderMenuScreen({
     title: 'Setup',


### PR DESCRIPTION
## What & why

`renderMenuScreen` in the interactive CLI (`./kritt setup`) built one flat array of lines (header, status details, options, footer) and truncated it to the terminal's row count from the top. On a short terminal (a small integrated terminal pane, for example), the selectable options — including the selection cursor (`›`) and the `↑↓ navigate` footer — could be pushed off-screen entirely. The user would only see the informational status bullets (`○ Claude login not set`, etc.) with no visible cursor and no way to tell what was selected or how to navigate.

The fix trims the informational detail lines first when space is tight, since that same state is already echoed in each option's own description (e.g. "Claude login — sign in with a Claude subscription" vs. "present"). The options list and footer are now always rendered, regardless of terminal height.

Closes #

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] docs / CI / tooling (CLI)

## Checklist

- [x] Commits use Conventional Commits (no empty `()` scope)
- [x] Commits are signed off (`git commit -s`) — DCO
- [x] Tests added/updated and passing (`node --test scripts/kritt.test.mjs scripts/kritt-ui.test.mjs` — 37/37 pass)
- [ ] Docs updated — not needed, no user-facing behavior/config changed beyond the bug fix
- [x] No secrets committed

## Notes for reviewers

Repro: render the setup menu with 7 status details + 8 options at `rows: 14` (a plausible small terminal pane height) — before the fix, the entire options list and footer are clipped, leaving only the status bullets. Added a regression test covering exactly this case in `scripts/kritt-ui.test.mjs`.