### PR TITLE
feat(frontend): improve active worker status

### DIFF
--- a/backend/src/lib/repo.js
+++ b/backend/src/lib/repo.js
@@ -452,11 +452,21 @@ export function cleanError(value) {
   return compactError(value);
 }
 
-function elapsedMsSince(value) {
-  if (!value) return null;
-  const then = new Date(value).getTime();
-  if (!Number.isFinite(then)) return null;
-  return Math.max(0, Date.now() - then);
+export function activeJobElapsedMs(row = {}, phase = effectivePhase(row), now = Date.now()) {
+  const recordedRunTime = Number(row.runTimeMs);
+  if (phase === 'writing_db' && Number.isFinite(recordedRunTime) && recordedRunTime >= 0) {
+    return recordedRunTime;
+  }
+  if (phase !== 'running_harness') return null;
+
+  // updatedAt is refreshed when the metadata enters running_harness. Using
+  // runStartedAt here would include workspace preparation and make the UI
+  // report a much longer duration than the active model process.
+  const harnessStartedAt = row.updatedAt || row.runStartedAt || row.insertedAt;
+  if (!harnessStartedAt) return null;
+  const startedAt = new Date(harnessStartedAt).getTime();
+  if (!Number.isFinite(startedAt)) return null;
+  return Math.max(0, now - startedAt);
 }
 
 export function errorIsFromPreviousRun(scan, error) {
@@ -484,8 +494,15 @@ function metadataTitle(row, stepsMap) {
   return `${step?.depth ?? '?'} · ${step?.name || `Step ${row.stepId.toString()}`}`;
 }
 
+export function activeJobWorkflowDepth(row = {}, step = null) {
+  if ((row.kind || 'step') !== 'step') return null;
+  const depth = Number(step?.depth);
+  return Number.isInteger(depth) && depth >= 0 ? depth : null;
+}
+
 function metadataJob(row, stepsMap) {
   const phase = effectivePhase(row);
+  const step = (row.kind || 'step') === 'step' ? stepsMap.get(row.stepId.toString()) : null;
   return {
     id: row.id.toString(),
     metadataId: row.id.toString(),
@@ -495,8 +512,9 @@ function metadataJob(row, stepsMap) {
     status: row.status,
     phase,
     phaseLabel: phaseLabel(phase),
+    depth: activeJobWorkflowDepth(row, step),
     startedAt: row.runStartedAt || row.insertedAt,
-    elapsedMs: elapsedMsSince(row.runStartedAt || row.insertedAt),
+    elapsedMs: activeJobElapsedMs(row, phase),
     runTimeMs: row.runTimeMs == null ? null : Number(row.runTimeMs),
     codexAccountEmail: row.codexAccountEmail || null,
     codexAccountId: row.codexAccountId || null,
@@ -656,7 +674,6 @@ async function statusSummariesByScan(scans, stepsMap, workflowsById) {
 
   for (const summary of summaries.values()) {
     summary.activeJobCount = summary.activeJobs.length;
-    summary.activeJobs = summary.activeJobs.slice(0, 5);
     summary.recentErrors = orderScanErrorsForDisplay(summary.recentErrors).slice(0, 5);
     summary.latestError = summary.recentErrors.find((error) => !error.previousRun) || null;
     summary.expectedStepLineages = summary.stepAttempts;

--- a/backend/src/lib/repo.js
+++ b/backend/src/lib/repo.js
@@ -494,15 +494,59 @@ function metadataTitle(row, stepsMap) {
   return `${step?.depth ?? '?'} · ${step?.name || `Step ${row.stepId.toString()}`}`;
 }
 
+function runtimeValue(configuration, snakeKey, camelKey = snakeKey) {
+  if (!configuration || typeof configuration !== 'object' || Array.isArray(configuration)) return null;
+  return configuration[snakeKey] || configuration[camelKey] || null;
+}
+
+export function activeJobRuntimeSelection(row = {}, step = null, scan = {}) {
+  const kind = row.kind || 'step';
+  const overrides = scan.modelOverrides;
+  const override =
+    kind === 'step' && step && overrides && typeof overrides === 'object' && !Array.isArray(overrides)
+      ? overrides[String(step.depth)]
+      : null;
+  const postProcessingEffort =
+    runtimeValue(scan.configuration, 'post_processing_thinking_effort', 'postProcessingThinkingEffort') ||
+    scan.thinkingEffort;
+  const postProcessingModel =
+    runtimeValue(scan.configuration, 'post_processing_model', 'postProcessingModel') || scan.model;
+  const postProcessingModelProvider =
+    runtimeValue(scan.configuration, 'post_processing_model_provider', 'postProcessingModelProvider') ||
+    scan.modelProvider;
+  const postProcessingHarness =
+    runtimeValue(scan.configuration, 'post_processing_harness', 'postProcessingHarness') || scan.harness;
+
+  return {
+    model: row.model || runtimeValue(override, 'model') || (kind === 'step' ? scan.model : postProcessingModel) || null,
+    modelProvider:
+      row.modelProvider ||
+      runtimeValue(override, 'model_provider', 'modelProvider') ||
+      (kind === 'step' ? scan.modelProvider : postProcessingModelProvider) ||
+      null,
+    harness:
+      row.harness ||
+      runtimeValue(override, 'harness') ||
+      (kind === 'step' ? scan.harness : postProcessingHarness) ||
+      null,
+    thinkingEffort:
+      row.thinkingEffort ||
+      runtimeValue(override, 'thinking_effort', 'thinkingEffort') ||
+      (kind === 'step' ? scan.thinkingEffort : postProcessingEffort) ||
+      null,
+  };
+}
+
 export function activeJobWorkflowDepth(row = {}, step = null) {
   if ((row.kind || 'step') !== 'step') return null;
   const depth = Number(step?.depth);
   return Number.isInteger(depth) && depth >= 0 ? depth : null;
 }
 
-function metadataJob(row, stepsMap) {
+function metadataJob(row, stepsMap, scan) {
   const phase = effectivePhase(row);
   const step = (row.kind || 'step') === 'step' ? stepsMap.get(row.stepId.toString()) : null;
+  const runtime = activeJobRuntimeSelection(row, step, scan);
   return {
     id: row.id.toString(),
     metadataId: row.id.toString(),
@@ -518,12 +562,13 @@ function metadataJob(row, stepsMap) {
     runTimeMs: row.runTimeMs == null ? null : Number(row.runTimeMs),
     codexAccountEmail: row.codexAccountEmail || null,
     codexAccountId: row.codexAccountId || null,
+    ...runtime,
   };
 }
 
-function metadataError(row, stepsMap) {
+function metadataError(row, stepsMap, scan) {
   return {
-    ...metadataJob(row, stepsMap),
+    ...metadataJob(row, stepsMap, scan),
     message: cleanError(row.error),
     knownError: knownError(row.error),
     insertedAt: row.insertedAt,
@@ -603,6 +648,10 @@ async function statusSummariesByScan(scans, stepsMap, workflowsById) {
         runTimeMs: true,
         codexAccountId: true,
         codexAccountEmail: true,
+        model: true,
+        modelProvider: true,
+        harness: true,
+        thinkingEffort: true,
         insertedAt: true,
         updatedAt: true,
       },
@@ -624,6 +673,10 @@ async function statusSummariesByScan(scans, stepsMap, workflowsById) {
         runTimeMs: true,
         codexAccountId: true,
         codexAccountEmail: true,
+        model: true,
+        modelProvider: true,
+        harness: true,
+        thinkingEffort: true,
         insertedAt: true,
         updatedAt: true,
       },
@@ -652,7 +705,8 @@ async function statusSummariesByScan(scans, stepsMap, workflowsById) {
   for (const row of activeRows) {
     const summary = summaries.get(row.scanId.toString());
     if (!summary) continue;
-    summary.activeJobs.push(metadataJob(row, stepsMap));
+    const scan = scansById.get(row.scanId.toString());
+    summary.activeJobs.push(metadataJob(row, stepsMap, scan));
   }
 
   for (const scan of scans) {
@@ -664,9 +718,9 @@ async function statusSummariesByScan(scans, stepsMap, workflowsById) {
   for (const row of errorRows) {
     const summary = summaries.get(row.scanId.toString());
     if (isDerivativeScanStatusError(row.error)) continue;
-    const error = metadataError(row, stepsMap);
-    if (!summary || !error.message) continue;
     const scan = scansById.get(row.scanId.toString());
+    const error = metadataError(row, stepsMap, scan);
+    if (!summary || !error.message) continue;
     error.previousRun = errorIsFromPreviousRun(scan, error);
     if (!error.previousRun && row.status === 'failed') summary.currentFailedAttempts += 1;
     summary.recentErrors.push(error);

--- a/backend/test/scanPresentation.test.js
+++ b/backend/test/scanPresentation.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   activeJobElapsedMs,
+  activeJobRuntimeSelection,
   activeJobWorkflowDepth,
   cleanError,
   configuredPostScriptIds,
@@ -35,6 +36,64 @@ test('active worker duration begins at the harness phase instead of the earlier 
   assert.equal(activeJobElapsedMs(row, row.phase, now), 56 * 60 * 1000);
   assert.equal(activeJobElapsedMs({ ...row, phase: 'building_workspace' }, 'building_workspace', now), null);
   assert.equal(activeJobElapsedMs({ ...row, runTimeMs: 1234 }, 'writing_db', now), 1234);
+});
+
+test('active worker runtime resolves persisted metadata, depth overrides, and scan fallbacks in order', () => {
+  const scan = {
+    model: 'scan-model',
+    modelProvider: 'codex',
+    harness: 'codex',
+    thinkingEffort: 'xhigh',
+    modelOverrides: {
+      2: {
+        model: 'depth-model',
+        model_provider: 'factory',
+        harness: 'droid',
+        thinking_effort: 'max',
+      },
+    },
+  };
+
+  assert.deepEqual(activeJobRuntimeSelection({ kind: 'step' }, { depth: 2 }, scan), {
+    model: 'depth-model',
+    modelProvider: 'factory',
+    harness: 'droid',
+    thinkingEffort: 'max',
+  });
+  assert.deepEqual(activeJobRuntimeSelection({ kind: 'step', model: 'persisted-model' }, { depth: 2 }, scan), {
+    model: 'persisted-model',
+    modelProvider: 'factory',
+    harness: 'droid',
+    thinkingEffort: 'max',
+  });
+});
+
+test('post-processing workers use their recorded runtime or configured fallback', () => {
+  const scan = {
+    model: 'scan-model',
+    modelProvider: 'codex',
+    harness: 'codex',
+    thinkingEffort: 'high',
+    configuration: {
+      post_processing_model: 'post-model',
+      post_processing_model_provider: 'factory',
+      post_processing_harness: 'droid',
+      post_processing_thinking_effort: 'xhigh',
+    },
+  };
+
+  assert.deepEqual(activeJobRuntimeSelection({ kind: 'post_script' }, null, scan), {
+    model: 'post-model',
+    modelProvider: 'factory',
+    harness: 'droid',
+    thinkingEffort: 'xhigh',
+  });
+  assert.deepEqual(activeJobRuntimeSelection({ kind: 'post_script', model: 'persisted-post-model' }, null, scan), {
+    model: 'persisted-post-model',
+    modelProvider: 'factory',
+    harness: 'droid',
+    thinkingEffort: 'xhigh',
+  });
 });
 
 test('lineage summary includes unclaimed fan-out work in the denominator', () => {

--- a/backend/test/scanPresentation.test.js
+++ b/backend/test/scanPresentation.test.js
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  activeJobElapsedMs,
+  activeJobWorkflowDepth,
   cleanError,
   configuredPostScriptIds,
   errorIsFromPreviousRun,
@@ -12,6 +14,28 @@ import {
 } from '../src/lib/repo.js';
 import { serializeScan } from '../src/lib/serialize.js';
 import { SCAN_STATUSES } from '../src/lib/constants.js';
+
+test('active workers expose workflow depth only for workflow steps', () => {
+  assert.equal(activeJobWorkflowDepth({ kind: 'step' }, { depth: 2 }), 2);
+  assert.equal(activeJobWorkflowDepth({}, { depth: 0 }), 0);
+  assert.equal(activeJobWorkflowDepth({ kind: 'post_script' }, { depth: 3 }), null);
+  assert.equal(activeJobWorkflowDepth({ kind: 'step' }, null), null);
+});
+
+test('active worker duration begins at the harness phase instead of the earlier metadata claim', () => {
+  const now = Date.parse('2026-08-02T12:00:00.000Z');
+  const row = {
+    status: 'running',
+    phase: 'running_harness',
+    runStartedAt: new Date('2026-08-02T09:00:00.000Z'),
+    updatedAt: new Date('2026-08-02T11:04:00.000Z'),
+    runTimeMs: 0,
+  };
+
+  assert.equal(activeJobElapsedMs(row, row.phase, now), 56 * 60 * 1000);
+  assert.equal(activeJobElapsedMs({ ...row, phase: 'building_workspace' }, 'building_workspace', now), null);
+  assert.equal(activeJobElapsedMs({ ...row, runTimeMs: 1234 }, 'writing_db', now), 1234);
+});
 
 test('lineage summary includes unclaimed fan-out work in the denominator', () => {
   const scan = { configuration: {} };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,6 +36,18 @@ body {
   --fail-bg: #fcebec;
   --stop: #8d8b85;
   --stop-bg: #f0efec;
+  --depth-0: #667085;
+  --depth-0-bg: #f1f3f5;
+  --depth-1: #087e8b;
+  --depth-1-bg: #e8f7f8;
+  --depth-2: #b26a00;
+  --depth-2-bg: #fff3dc;
+  --depth-3: #7048c8;
+  --depth-3-bg: #f2edff;
+  --depth-4: #238636;
+  --depth-4-bg: #eaf7ee;
+  --depth-5: #c12b55;
+  --depth-5-bg: #fff0f4;
   --shadow: 0 1px 2px rgba(20, 20, 18, 0.05);
 }
 [data-theme='dark'] {
@@ -63,6 +75,18 @@ body {
   --fail-bg: #2a1414;
   --stop: #7c7f8a;
   --stop-bg: #1a1b20;
+  --depth-0: #a7adb8;
+  --depth-0-bg: #1d2026;
+  --depth-1: #45c4d4;
+  --depth-1-bg: #10262b;
+  --depth-2: #f2b84b;
+  --depth-2-bg: #2a200d;
+  --depth-3: #ad91ff;
+  --depth-3-bg: #211a38;
+  --depth-4: #53d47c;
+  --depth-4-bg: #10281a;
+  --depth-5: #ff7998;
+  --depth-5-bg: #30141d;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 

--- a/frontend/src/pages/ScanDetail.jsx
+++ b/frontend/src/pages/ScanDetail.jsx
@@ -1204,12 +1204,177 @@ function scanErrorTimestamp(error) {
   return null;
 }
 
+const EXTENDED_ACTIVE_JOB_MS = 45 * 60 * 1000;
+const ACTIVE_JOB_DEPTH_PALETTE_SIZE = 6;
+
+export function activeJobWorkflowDepth(job) {
+  if (job?.kind && job.kind !== 'step') return null;
+  if (job?.depth != null && job.depth !== '') {
+    const explicitDepth = Number(job.depth);
+    if (Number.isInteger(explicitDepth) && explicitDepth >= 0) return explicitDepth;
+  }
+  const titleMatch = `${job?.title || ''}`.match(/^\s*(\d+)\s*·/);
+  if (!titleMatch) return null;
+  const titleDepth = Number(titleMatch[1]);
+  return Number.isInteger(titleDepth) ? titleDepth : null;
+}
+
+function activeJobStage(job) {
+  const depth = activeJobWorkflowDepth(job);
+  if (depth != null) return { key: `depth-${depth}`, label: `D${depth}`, depth };
+  if (job?.kind && job.kind !== 'step') return { key: 'post', label: 'POST', depth: null };
+  return { key: 'work', label: 'WORK', depth: null };
+}
+
+function activeJobDepthStyle(stage) {
+  if (stage.depth == null) {
+    return { color: 'var(--text-2)', background: 'var(--surface)' };
+  }
+  const paletteIndex = stage.depth % ACTIVE_JOB_DEPTH_PALETTE_SIZE;
+  return {
+    color: `var(--depth-${paletteIndex})`,
+    background: `var(--depth-${paletteIndex}-bg)`,
+  };
+}
+
+export function activeJobDepthSummary(jobs = []) {
+  const counts = new Map();
+  for (const job of jobs) {
+    const stage = activeJobStage(job);
+    const current = counts.get(stage.key);
+    if (current) current.count += 1;
+    else counts.set(stage.key, { ...stage, count: 1 });
+  }
+  return [...counts.values()].sort((left, right) => {
+    if (left.depth != null && right.depth != null) return left.depth - right.depth;
+    if (left.depth != null) return -1;
+    if (right.depth != null) return 1;
+    return left.label.localeCompare(right.label);
+  });
+}
+
+export function formatActiveJobElapsed(value) {
+  const milliseconds = Number(value);
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) return null;
+  const seconds = Math.floor(milliseconds / 1000);
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function ActiveJobCard({ job }) {
+  const elapsed = formatActiveJobElapsed(job.elapsedMs);
+  const extended = Number(job.elapsedMs) >= EXTENDED_ACTIVE_JOB_MS;
+  const stage = activeJobStage(job);
+  const depthStyle = activeJobDepthStyle(stage);
+
+  return (
+    <article
+      aria-label={`${stage.depth == null ? stage.label : `Workflow depth ${stage.depth}`} worker: ${job.title || job.source || 'Active worker'}`}
+      style={{
+        minWidth: 0,
+        border: `1px solid ${extended ? 'var(--pend)' : 'var(--border)'}`,
+        borderRadius: 9,
+        background: `linear-gradient(135deg, ${depthStyle.background} 0%, var(--surface-2) 48%)`,
+        padding: '10px 11px',
+      }}
+    >
+      <div
+        className="mono"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 10,
+          fontSize: 10.5,
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 7,
+            minWidth: 0,
+            color: 'var(--run)',
+          }}
+        >
+          <span
+            title={stage.depth == null ? stage.label : `Workflow depth ${stage.depth}`}
+            style={{
+              flex: '0 0 auto',
+              border: `1px solid color-mix(in srgb, ${depthStyle.color} 32%, var(--border))`,
+              borderRadius: 5,
+              background: depthStyle.background,
+              color: depthStyle.color,
+              fontSize: 9.5,
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+              lineHeight: 1,
+              padding: '4px 5px 3px',
+            }}
+          >
+            {stage.label}
+          </span>
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              flex: '0 0 auto',
+              borderRadius: '50%',
+              background: 'var(--run)',
+            }}
+          />
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {job.phaseLabel || 'Running'}
+          </span>
+        </span>
+        <span
+          title={
+            extended
+              ? 'Extended run. This is informational and does not mean the worker is stuck or failed.'
+              : 'Current active harness duration'
+          }
+          style={{ flex: '0 0 auto', color: extended ? 'var(--pend)' : 'var(--text-2)' }}
+        >
+          {extended ? 'extended · ' : ''}
+          {elapsed || 'starting'}
+        </span>
+      </div>
+
+      <div
+        title={job.title}
+        style={{
+          color: 'var(--text)',
+          fontSize: 12.5,
+          fontWeight: 600,
+          lineHeight: 1.35,
+          marginTop: 8,
+          overflowWrap: 'anywhere',
+          whiteSpace: 'normal',
+        }}
+      >
+        {job.title || job.source || 'Active worker'}
+      </div>
+    </article>
+  );
+}
+
 export function ScanStatusPanel({ scan }) {
   const summary = scan.statusSummary || {};
   const rateLimited = scan.status === 'rate_limited';
   const completedLineages = summary.completedStepLineages ?? summary.stepCompletedAttempts ?? 0;
   const expectedLineages = summary.expectedStepLineages ?? summary.stepAttempts ?? 0;
   const activeJobs = summary.activeJobs || [];
+  const activeDepths = activeJobDepthSummary(activeJobs);
+  const longestActiveJobMs = activeJobs.reduce((longest, job) => {
+    const elapsed = Number(job?.elapsedMs);
+    return Number.isFinite(elapsed) ? Math.max(longest, elapsed) : longest;
+  }, 0);
   const recentErrors = summary.recentErrors || [];
   const currentFailedAttempts = summary.currentFailedAttempts ?? summary.failedAttempts ?? 0;
   const [expandedErrorIds, setExpandedErrorIds] = useState(() => new Set());
@@ -1298,36 +1463,77 @@ export function ScanStatusPanel({ scan }) {
       </div>
 
       {activeJobs.length > 0 && (
-        <div style={{ marginTop: 14, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-          {activeJobs.map((job) => (
-            <span
-              key={job.id}
-              className="mono"
-              style={{
-                display: 'inline-flex',
-                gap: 6,
-                alignItems: 'center',
-                maxWidth: '100%',
-                padding: '4px 8px',
-                borderRadius: 7,
-                background: 'var(--run-bg)',
-                color: 'var(--run)',
-                fontSize: 11.5,
-              }}
-            >
-              <span>{job.phaseLabel}</span>
-              <span
-                style={{
-                  color: 'var(--text-2)',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {job.title}
-              </span>
+        <div style={{ marginTop: 16 }}>
+          <div
+            className="mono"
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              flexWrap: 'wrap',
+              gap: 8,
+              marginBottom: 8,
+            }}
+          >
+            <span style={{ color: 'var(--text-2)', fontSize: 11.5 }}>Active workers</span>
+            <span style={{ color: 'var(--text-3)', fontSize: 10.5 }}>
+              {activeJobs.length} active
+              {longestActiveJobMs > 0 ? ` · longest ${formatActiveJobElapsed(longestActiveJobMs)}` : ''}
             </span>
-          ))}
+          </div>
+          <div
+            aria-label="Active workers by workflow depth"
+            className="mono"
+            style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 9 }}
+          >
+            {activeDepths.map((stage) => {
+              const depthStyle = activeJobDepthStyle(stage);
+              const description =
+                stage.depth == null
+                  ? `${stage.label}: ${stage.count} active worker${stage.count === 1 ? '' : 's'}`
+                  : `Depth ${stage.depth}: ${stage.count} active worker${stage.count === 1 ? '' : 's'}`;
+              return (
+                <span
+                  key={stage.key}
+                  title={description}
+                  aria-label={description}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    border: `1px solid color-mix(in srgb, ${depthStyle.color} 30%, var(--border))`,
+                    borderRadius: 999,
+                    background: depthStyle.background,
+                    color: depthStyle.color,
+                    fontSize: 10,
+                    lineHeight: 1,
+                    padding: '5px 7px',
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{ width: 6, height: 6, borderRadius: '50%', background: depthStyle.color }}
+                  />
+                  <strong style={{ fontWeight: 700 }}>{stage.label}</strong>
+                  <span>{stage.count}</span>
+                </span>
+              );
+            })}
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(230px, 1fr))',
+              gap: 8,
+            }}
+          >
+            {activeJobs.map((job) => (
+              <ActiveJobCard key={job.id} job={job} />
+            ))}
+          </div>
+          <div className="mono" style={{ color: 'var(--text-3)', fontSize: 9.5, marginTop: 7 }}>
+            Live duration is informational. The engine reports failures separately below.
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/ScanDetail.jsx
+++ b/frontend/src/pages/ScanDetail.jsx
@@ -1206,6 +1206,16 @@ function scanErrorTimestamp(error) {
 
 const EXTENDED_ACTIVE_JOB_MS = 45 * 60 * 1000;
 const ACTIVE_JOB_DEPTH_PALETTE_SIZE = 6;
+const ACTIVE_JOB_HARNESS_LABELS = Object.freeze({
+  codex: 'Codex CLI',
+  'claude-code': 'Claude Code',
+  droid: 'Factory Droid',
+});
+
+function activeJobHarnessLabel(value) {
+  const harness = `${value || ''}`.trim();
+  return ACTIVE_JOB_HARNESS_LABELS[harness] || harness || 'Not reported';
+}
 
 export function activeJobWorkflowDepth(job) {
   if (job?.kind && job.kind !== 'step') return null;
@@ -1271,6 +1281,8 @@ function ActiveJobCard({ job }) {
   const extended = Number(job.elapsedMs) >= EXTENDED_ACTIVE_JOB_MS;
   const stage = activeJobStage(job);
   const depthStyle = activeJobDepthStyle(stage);
+  const model = `${job.model || ''}`.trim() || 'Not reported';
+  const harness = activeJobHarnessLabel(job.harness);
 
   return (
     <article
@@ -1359,6 +1371,81 @@ function ActiveJobCard({ job }) {
         }}
       >
         {job.title || job.source || 'Active worker'}
+      </div>
+
+      <div
+        className="mono"
+        aria-label={`Model: ${model}; Harness: ${harness}`}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) auto',
+          alignItems: 'end',
+          gap: 10,
+          borderTop: '1px solid var(--border)',
+          marginTop: 9,
+          paddingTop: 8,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              color: 'var(--text-3)',
+              fontSize: 8.5,
+              letterSpacing: '0.08em',
+              lineHeight: 1,
+              textTransform: 'uppercase',
+            }}
+          >
+            Model
+          </div>
+          <div
+            title={`Model: ${model}`}
+            style={{
+              color: 'var(--text)',
+              fontSize: 11.5,
+              fontWeight: 650,
+              lineHeight: 1.25,
+              marginTop: 5,
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {model}
+          </div>
+        </div>
+        <div style={{ minWidth: 0, textAlign: 'right' }}>
+          <div
+            style={{
+              color: 'var(--text-3)',
+              fontSize: 8.5,
+              letterSpacing: '0.08em',
+              lineHeight: 1,
+              textTransform: 'uppercase',
+            }}
+          >
+            Harness
+          </div>
+          <span
+            title={`Harness: ${harness}`}
+            style={{
+              display: 'inline-block',
+              maxWidth: 120,
+              border: '1px solid var(--border-2)',
+              borderRadius: 999,
+              background: 'var(--surface)',
+              color: 'var(--text-2)',
+              fontSize: 9.5,
+              lineHeight: 1,
+              marginTop: 4,
+              overflow: 'hidden',
+              padding: '4px 6px',
+              textOverflow: 'ellipsis',
+              verticalAlign: 'bottom',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {harness}
+          </span>
+        </div>
       </div>
     </article>
   );

--- a/frontend/src/pages/ScanDetail.test.jsx
+++ b/frontend/src/pages/ScanDetail.test.jsx
@@ -4,6 +4,9 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { MemoryRouter } from 'react-router-dom';
 
 import {
+  activeJobDepthSummary,
+  activeJobWorkflowDepth,
+  formatActiveJobElapsed,
   loadModelReferences,
   mergeRunSettingsDraft,
   runSettingsDraft,
@@ -155,6 +158,91 @@ describe('scan lifecycle actions', () => {
       canResume: false,
       canDelete: true,
     });
+  });
+});
+
+describe('active worker presentation', () => {
+  it('derives workflow depth explicitly and from legacy active-worker titles', () => {
+    expect(activeJobWorkflowDepth({ depth: 3, title: '1 · ignored fallback' })).toBe(3);
+    expect(activeJobWorkflowDepth({ title: '2 · Derive concrete exploit candidates' })).toBe(2);
+    expect(activeJobWorkflowDepth({ kind: 'post_script', depth: 4, title: '4 · ignored' })).toBeNull();
+    expect(activeJobWorkflowDepth({ title: 'Post processing' })).toBeNull();
+  });
+
+  it('summarizes active workers by depth in stable workflow order', () => {
+    expect(
+      activeJobDepthSummary([
+        { depth: 2 },
+        { title: '1 · Trace security-sensitive flows' },
+        { depth: 2 },
+        { kind: 'post_script', title: 'Report Creator' },
+      ])
+    ).toEqual([
+      { key: 'depth-1', label: 'D1', depth: 1, count: 1 },
+      { key: 'depth-2', label: 'D2', depth: 2, count: 2 },
+      { key: 'post', label: 'POST', depth: null, count: 1 },
+    ]);
+  });
+
+  it('formats active harness duration without implying that extended work is stuck', () => {
+    expect(formatActiveJobElapsed(0)).toBe('<1s');
+    expect(formatActiveJobElapsed(56 * 60 * 1000)).toBe('56m');
+    expect(formatActiveJobElapsed((2 * 60 + 7) * 60 * 1000)).toBe('2h 7m');
+  });
+
+  it('renders every server-provided active worker', () => {
+    const html = renderToStaticMarkup(
+      createElement(ScanStatusPanel, {
+        scan: {
+          status: 'running',
+          statusSummary: {
+            totalAttempts: 10,
+            activeJobs: Array.from({ length: 10 }, (_, index) => ({
+              id: `worker-${index + 1}`,
+              phaseLabel: 'Running harness',
+              title: `Worker ${index + 1}`,
+            })),
+          },
+        },
+      })
+    );
+
+    expect(html).toContain('Worker 1');
+    expect(html).toContain('Worker 10');
+  });
+
+  it('renders a complete depth-aware active-worker card', () => {
+    const html = renderToStaticMarkup(
+      createElement(ScanStatusPanel, {
+        scan: {
+          status: 'running',
+          statusSummary: {
+            totalAttempts: 1,
+            activeJobs: [
+              {
+                id: '983',
+                depth: 2,
+                phaseLabel: 'Running harness',
+                title: '2 · Derive concrete exploit candidates',
+                elapsedMs: 56 * 60 * 1000,
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(html).toContain('Active workers');
+    expect(html).toContain('Depth 2: 1 active worker');
+    expect(html).toContain('Workflow depth 2 worker');
+    expect(html).toContain('D2');
+    expect(html).toContain('longest 56m');
+    expect(html).toContain('extended · 56m');
+    expect(html).toContain('2 · Derive concrete exploit candidates');
+    expect(html).toContain('white-space:normal');
+    expect(html).toContain('overflow-wrap:anywhere');
+    expect(html).toContain('The engine reports failures separately below.');
+    expect(html).not.toContain('Stuck');
   });
 });
 

--- a/frontend/src/pages/ScanDetail.test.jsx
+++ b/frontend/src/pages/ScanDetail.test.jsx
@@ -225,6 +225,10 @@ describe('active worker presentation', () => {
                 phaseLabel: 'Running harness',
                 title: '2 · Derive concrete exploit candidates',
                 elapsedMs: 56 * 60 * 1000,
+                model: 'gpt-5.6-luna',
+                modelProvider: 'codex',
+                harness: 'codex',
+                thinkingEffort: 'max',
               },
             ],
           },
@@ -239,6 +243,9 @@ describe('active worker presentation', () => {
     expect(html).toContain('longest 56m');
     expect(html).toContain('extended · 56m');
     expect(html).toContain('2 · Derive concrete exploit candidates');
+    expect(html).toContain('Model: gpt-5.6-luna; Harness: Codex CLI');
+    expect(html).toContain('gpt-5.6-luna');
+    expect(html).toContain('Codex CLI');
     expect(html).toContain('white-space:normal');
     expect(html).toContain('overflow-wrap:anywhere');
     expect(html).toContain('The engine reports failures separately below.');


### PR DESCRIPTION
## What changed

- replace the compact active-job chips with responsive worker cards
- show every active worker instead of truncating the API response to five
- group workers by workflow depth, with light/dark theme depth colors
- keep full step names visible and show the longest active harness duration
- distinguish an extended run from a failed or stuck worker
- measure elapsed time from the harness phase rather than the earlier metadata claim
- show each worker's exact model and a friendly harness badge on the card
- expose persisted model/provider/harness/thinking-effort metadata through the active-job API, with depth and scan fallbacks for older rows

## Why

Parallel scans can run many workers across several depths. The existing five-item chip list hides workers, truncates long step names, and can make duration look longer than the actual model process because it includes preparation time.

A scan may also mix models or harnesses through depth overrides and post-processing settings, so the run-level configuration alone does not always identify what an individual worker is using. The expanded cards now make concurrency, workflow progress, and the runtime selection for each worker understandable at a glance.

## Validation

- `frontend: npm run lint`
- `frontend: npm test -- --run src/pages/ScanDetail.test.jsx` (21 tests)
- `frontend: npm run build`
- `backend: npm run lint`
- `backend: node --test test/scanPresentation.test.js` (17 tests)
- targeted Prettier checks for all changed files
- `git diff --check`