### PR TITLE
feat: support separate post-processing models

### DIFF
--- a/backend/src/lib/serialize.js
+++ b/backend/src/lib/serialize.js
@@ -302,6 +302,17 @@ export function serializeScan(
 ) {
   const commit = scan.commitSha || '';
   const agentSkillIds = (scan.agentSkillIds || []).map((id) => id.toString());
+  const configuration =
+    scan.configuration && typeof scan.configuration === 'object' && !Array.isArray(scan.configuration)
+      ? scan.configuration
+      : {};
+  const postProcessingModel = configuration.post_processing_model ?? configuration.postProcessingModel;
+  const postProcessingModelProvider =
+    configuration.post_processing_model_provider ?? configuration.postProcessingModelProvider;
+  const postProcessingHarness = configuration.post_processing_harness ?? configuration.postProcessingHarness;
+  const postProcessingModelOverride = [postProcessingModel, postProcessingModelProvider, postProcessingHarness].some(
+    (value) => value !== undefined && value !== null && `${value}`.trim() !== ''
+  );
   return {
     id: scan.id.toString(),
     repoFull: scan.repoFull,
@@ -311,14 +322,18 @@ export function serializeScan(
     commitShort: commit.length > 7 ? commit.slice(0, 7) : commit,
     repoScope: scan.repoScope,
     dependencies: serializeDependencies(scan),
-    configuration: scan.configuration || {},
+    configuration,
     model: scan.model,
     modelProvider: scan.modelProvider ?? null,
     harness: scan.harness,
     thinkingEffort: scan.thinkingEffort ?? null,
+    postProcessingModel: postProcessingModel ?? scan.model,
+    postProcessingModelProvider: postProcessingModelProvider ?? scan.modelProvider ?? null,
+    postProcessingHarness: postProcessingHarness ?? scan.harness,
+    postProcessingModelOverride,
     postProcessingThinkingEffort:
-      scan.configuration?.post_processing_thinking_effort ??
-      scan.configuration?.postProcessingThinkingEffort ??
+      configuration.post_processing_thinking_effort ??
+      configuration.postProcessingThinkingEffort ??
       scan.thinkingEffort ??
       null,
     modelOverrides: serializeModelOverrides(scan.modelOverrides),

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -137,6 +137,62 @@ export function validatePostProcessingThinkingEffort(value, { harness, fallback 
   return effort;
 }
 
+export function validatePostProcessingModelSelection(value = {}, fallback = {}) {
+  const selection = modelSelectionValidation({
+    model: value.model ?? fallback.model,
+    model_provider: value.modelProvider ?? value.model_provider ?? fallback.modelProvider ?? fallback.model_provider,
+    harness: value.harness ?? fallback.harness,
+    thinking_effort:
+      value.thinkingEffort ?? value.thinking_effort ?? fallback.thinkingEffort ?? fallback.thinking_effort,
+  });
+  if (selection.errors.length) {
+    const fields = {
+      model: 'post_processing_model',
+      model_provider: 'post_processing_model_provider',
+      harness: 'post_processing_harness',
+      thinking_effort: 'post_processing_thinking_effort',
+    };
+    throw new ValidationError(
+      selection.errors.map((item) => ({
+        ...item,
+        field: fields[item.field] || `post_processing_${item.field}`,
+      }))
+    );
+  }
+  return selection.normalized;
+}
+
+function postProcessingRuntimeInput(body = {}, configuration = {}) {
+  const config =
+    configuration && typeof configuration === 'object' && !Array.isArray(configuration) ? configuration : {};
+  return {
+    model:
+      body.post_processing_model ??
+      body.postProcessingModel ??
+      config.post_processing_model ??
+      config.postProcessingModel,
+    modelProvider:
+      body.post_processing_model_provider ??
+      body.postProcessingModelProvider ??
+      config.post_processing_model_provider ??
+      config.postProcessingModelProvider,
+    harness:
+      body.post_processing_harness ??
+      body.postProcessingHarness ??
+      config.post_processing_harness ??
+      config.postProcessingHarness,
+    thinkingEffort:
+      body.post_processing_thinking_effort ??
+      body.postProcessingThinkingEffort ??
+      config.post_processing_thinking_effort ??
+      config.postProcessingThinkingEffort,
+  };
+}
+
+function hasPostProcessingModelOverride(value = {}) {
+  return [value.model, value.modelProvider, value.harness].some((item) => item !== undefined && item !== null);
+}
+
 export function validateModelOverrides(value, { allowedDepths = null, field = 'model_overrides' } = {}) {
   if (value === undefined || value === null) return {};
   if (!isObjectMap(value)) {
@@ -742,18 +798,14 @@ export function validateScan(body, { localNames = null } = {}) {
       push('configuration', 'Configuration is not valid JSON.');
     }
   }
-  let postProcessingThinkingEffort = selection.normalized.thinkingEffort;
+  const postProcessingInput = postProcessingRuntimeInput(body, configuration);
+  const postProcessingModelOverride = hasPostProcessingModelOverride(postProcessingInput);
+  let postProcessingSelection = {
+    ...selection.normalized,
+    thinkingEffort: postProcessingInput.thinkingEffort ?? selection.normalized.thinkingEffort,
+  };
   try {
-    const configuredPostProcessingThinkingEffort =
-      body?.post_processing_thinking_effort ??
-      body?.postProcessingThinkingEffort ??
-      (configuration && typeof configuration === 'object' && !Array.isArray(configuration)
-        ? (configuration.post_processing_thinking_effort ?? configuration.postProcessingThinkingEffort)
-        : undefined);
-    postProcessingThinkingEffort = validatePostProcessingThinkingEffort(configuredPostProcessingThinkingEffort, {
-      harness: selection.normalized.harness,
-      fallback: selection.normalized.thinkingEffort,
-    });
+    postProcessingSelection = validatePostProcessingModelSelection(postProcessingInput, selection.normalized);
   } catch (error) {
     if (error instanceof ValidationError) errors.push(...error.errors);
     else throw error;
@@ -787,7 +839,9 @@ export function validateScan(body, { localNames = null } = {}) {
     dependencies, // [{ kind, repoFull, commitSha }]
     configuration,
     ...selection.normalized,
-    postProcessingThinkingEffort,
+    postProcessingSelection,
+    postProcessingModelOverride,
+    postProcessingThinkingEffort: postProcessingSelection.thinkingEffort,
     modelOverrides,
     severityRanker,
     extra,
@@ -802,12 +856,22 @@ export function validateScanRuntimeSettings(body, current = {}, options = {}) {
 export function validateProspectiveScanRuntimeSettings(body, current = {}, { allowedDepths = null } = {}) {
   const data = {};
   const hasOwn = (key) => Object.prototype.hasOwnProperty.call(body || {}, key);
+  const bodyValue = (snakeKey, camelKey) => (hasOwn(snakeKey) ? body?.[snakeKey] : body?.[camelKey]);
   const hasModel = hasOwn('model');
   const hasProvider = hasOwn('model_provider') || hasOwn('modelProvider');
   const hasHarness = hasOwn('harness');
   const hasThinkingEffort = hasOwn('thinking_effort') || hasOwn('thinkingEffort');
+  const hasPostProcessingModel = hasOwn('post_processing_model') || hasOwn('postProcessingModel');
+  const hasPostProcessingModelProvider =
+    hasOwn('post_processing_model_provider') || hasOwn('postProcessingModelProvider');
+  const hasPostProcessingHarness = hasOwn('post_processing_harness') || hasOwn('postProcessingHarness');
   const hasPostProcessingThinkingEffort =
     hasOwn('post_processing_thinking_effort') || hasOwn('postProcessingThinkingEffort');
+  const hasPostProcessingRuntime =
+    hasPostProcessingModel ||
+    hasPostProcessingModelProvider ||
+    hasPostProcessingHarness ||
+    hasPostProcessingThinkingEffort;
   const hasModelOverrides = hasOwn('model_overrides') || hasOwn('modelOverrides');
 
   if (
@@ -815,7 +879,7 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
     !hasProvider &&
     !hasHarness &&
     !hasThinkingEffort &&
-    !hasPostProcessingThinkingEffort &&
+    !hasPostProcessingRuntime &&
     !hasModelOverrides
   ) {
     return { data, selection: null, postProcessingSelection: null, modelOverrides: null };
@@ -842,25 +906,38 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
     current.configuration && typeof current.configuration === 'object' && !Array.isArray(current.configuration)
       ? current.configuration
       : {};
-  const explicitCurrentPostProcessingThinkingEffort =
-    current.postProcessingThinkingEffort ??
-    currentConfiguration.post_processing_thinking_effort ??
-    currentConfiguration.postProcessingThinkingEffort;
-  const currentPostProcessingThinkingEffort =
-    explicitCurrentPostProcessingThinkingEffort ?? prospectiveSelection.thinkingEffort;
-  const postProcessingThinkingEffort = validatePostProcessingThinkingEffort(
-    hasPostProcessingThinkingEffort
-      ? (body?.post_processing_thinking_effort ?? body?.postProcessingThinkingEffort)
-      : currentPostProcessingThinkingEffort,
-    {
-      harness: prospectiveSelection.harness,
-      fallback: prospectiveSelection.thinkingEffort,
-    }
-  );
-  const postProcessingSelection =
-    selection || hasPostProcessingThinkingEffort
-      ? { ...prospectiveSelection, thinkingEffort: postProcessingThinkingEffort }
-      : null;
+  const currentPostProcessingInput = postProcessingRuntimeInput({}, currentConfiguration);
+  const clearPostProcessingModelOverride =
+    hasPostProcessingModel &&
+    hasPostProcessingModelProvider &&
+    hasPostProcessingHarness &&
+    [
+      bodyValue('post_processing_model', 'postProcessingModel'),
+      bodyValue('post_processing_model_provider', 'postProcessingModelProvider'),
+      bodyValue('post_processing_harness', 'postProcessingHarness'),
+    ].every((value) => value === null || value === '');
+  const nextPostProcessingInput = clearPostProcessingModelOverride
+    ? {
+        thinkingEffort: hasPostProcessingThinkingEffort
+          ? bodyValue('post_processing_thinking_effort', 'postProcessingThinkingEffort')
+          : currentPostProcessingInput.thinkingEffort,
+      }
+    : {
+        model: hasPostProcessingModel
+          ? bodyValue('post_processing_model', 'postProcessingModel')
+          : currentPostProcessingInput.model,
+        modelProvider: hasPostProcessingModelProvider
+          ? bodyValue('post_processing_model_provider', 'postProcessingModelProvider')
+          : currentPostProcessingInput.modelProvider,
+        harness: hasPostProcessingHarness
+          ? bodyValue('post_processing_harness', 'postProcessingHarness')
+          : currentPostProcessingInput.harness,
+        thinkingEffort: hasPostProcessingThinkingEffort
+          ? bodyValue('post_processing_thinking_effort', 'postProcessingThinkingEffort')
+          : currentPostProcessingInput.thinkingEffort,
+      };
+  const postProcessingSelection = validatePostProcessingModelSelection(nextPostProcessingInput, prospectiveSelection);
+  const postProcessingSelectionToCheck = selection || hasPostProcessingRuntime ? postProcessingSelection : null;
   const modelOverrides = hasModelOverrides
     ? validateModelOverrides(body?.model_overrides ?? body?.modelOverrides, { allowedDepths })
     : null;
@@ -869,8 +946,13 @@ export function validateProspectiveScanRuntimeSettings(body, current = {}, { all
   if (hasProvider) data.modelProvider = selection.modelProvider;
   if (hasHarness) data.harness = selection.harness;
   if (hasThinkingEffort) data.thinkingEffort = selection.thinkingEffort;
-  if (hasPostProcessingThinkingEffort) data.postProcessingThinkingEffort = postProcessingThinkingEffort;
+  if (hasPostProcessingModel || hasPostProcessingModelProvider || hasPostProcessingHarness) {
+    data.postProcessingModel = clearPostProcessingModelOverride ? null : postProcessingSelection.model;
+    data.postProcessingModelProvider = clearPostProcessingModelOverride ? null : postProcessingSelection.modelProvider;
+    data.postProcessingHarness = clearPostProcessingModelOverride ? null : postProcessingSelection.harness;
+  }
+  if (hasPostProcessingThinkingEffort) data.postProcessingThinkingEffort = postProcessingSelection.thinkingEffort;
   if (hasModelOverrides) data.modelOverrides = modelOverrides;
 
-  return { data, selection, postProcessingSelection, modelOverrides };
+  return { data, selection, postProcessingSelection: postProcessingSelectionToCheck, modelOverrides };
 }

--- a/backend/src/routes/scans.js
+++ b/backend/src/routes/scans.js
@@ -177,6 +177,9 @@ export async function validateScanRuntimeUpdate(body, current, { assertAvailable
   if (Object.prototype.hasOwnProperty.call(runtime.data, 'postProcessingThinkingEffort')) {
     data.postProcessingThinkingEffort = runtime.data.postProcessingThinkingEffort;
   }
+  for (const key of ['postProcessingModel', 'postProcessingModelProvider', 'postProcessingHarness']) {
+    if (Object.prototype.hasOwnProperty.call(runtime.data, key)) data[key] = runtime.data[key];
+  }
   if (runtime.modelOverrides !== null) {
     await assertModelOverridesAvailable(runtime.modelOverrides, assertAvailable);
     data.modelOverrides = runtime.modelOverrides;
@@ -244,14 +247,28 @@ export async function patchScanIfPresent(tx, scanId, body, { assertAvailable, av
     assertAvailable: availabilityChecker,
     allowedDepths,
   });
-  if (Object.prototype.hasOwnProperty.call(runtimeData, 'postProcessingThinkingEffort')) {
-    data.configuration = {
+  const postProcessingConfigurationKeys = {
+    postProcessingModel: 'post_processing_model',
+    postProcessingModelProvider: 'post_processing_model_provider',
+    postProcessingHarness: 'post_processing_harness',
+    postProcessingThinkingEffort: 'post_processing_thinking_effort',
+  };
+  if (
+    Object.keys(postProcessingConfigurationKeys).some((key) => Object.prototype.hasOwnProperty.call(runtimeData, key))
+  ) {
+    const configuration = {
       ...(existing.configuration && typeof existing.configuration === 'object' && !Array.isArray(existing.configuration)
         ? existing.configuration
         : {}),
-      post_processing_thinking_effort: runtimeData.postProcessingThinkingEffort,
     };
-    delete runtimeData.postProcessingThinkingEffort;
+    for (const [runtimeKey, configurationKey] of Object.entries(postProcessingConfigurationKeys)) {
+      if (!Object.prototype.hasOwnProperty.call(runtimeData, runtimeKey)) continue;
+      const value = runtimeData[runtimeKey];
+      if (value === null) delete configuration[configurationKey];
+      else configuration[configurationKey] = value;
+      delete runtimeData[runtimeKey];
+    }
+    data.configuration = configuration;
   }
   Object.assign(data, runtimeData);
   if (Object.keys(data).length === 0) {
@@ -379,10 +396,7 @@ router.post('/', async (req, res, next) => {
   try {
     const valid = validateScan(req.body, { localNames: localRepoNames() });
     await assertModelSelectionAvailable(valid);
-    await assertModelSelectionAvailable({
-      ...valid,
-      thinkingEffort: valid.postProcessingThinkingEffort,
-    });
+    await assertSelectionAvailable(assertModelSelectionAvailable, valid.postProcessingSelection, 'post_processing');
     const activeScanCount = await prisma.scan.count({ where: { status: { in: ACTIVE_SCAN_STATUSES } } });
     const launchDecision = scanLaunchDecision(req.body, activeScanCount);
     if (launchDecision.kind === 'choice-required') {
@@ -531,6 +545,13 @@ router.post('/', async (req, res, next) => {
             post_script_ids: configuredPostScriptIds,
             agent_skill_ids: configuredAgentSkillIds,
             post_processing_thinking_effort: valid.postProcessingThinkingEffort,
+            ...(valid.postProcessingModelOverride
+              ? {
+                  post_processing_model: valid.postProcessingSelection.model,
+                  post_processing_model_provider: valid.postProcessingSelection.modelProvider,
+                  post_processing_harness: valid.postProcessingSelection.harness,
+                }
+              : {}),
           },
           model: valid.model,
           modelProvider: valid.modelProvider,

--- a/backend/test/dataIntegrity.test.js
+++ b/backend/test/dataIntegrity.test.js
@@ -254,6 +254,67 @@ test('runtime scan updates validate a separate post-processing thinking effort',
   ]);
 });
 
+test('runtime scan updates set and clear an independent post-processing model selection', async () => {
+  const current = {
+    model: 'gpt-5.5',
+    modelProvider: 'codex',
+    harness: 'codex',
+    thinkingEffort: 'high',
+    configuration: { post_processing_thinking_effort: 'high' },
+  };
+  const checkedSelections = [];
+
+  const data = await validateScanRuntimeUpdate(
+    {
+      post_processing_model: 'claude-sonnet',
+      post_processing_model_provider: 'claude',
+      post_processing_harness: 'claude-code',
+      post_processing_thinking_effort: 'medium',
+    },
+    current,
+    { assertAvailable: async (selection) => checkedSelections.push(selection) }
+  );
+
+  assert.deepEqual(data, {
+    postProcessingModel: 'claude-sonnet',
+    postProcessingModelProvider: 'claude',
+    postProcessingHarness: 'claude-code',
+    postProcessingThinkingEffort: 'medium',
+  });
+  assert.deepEqual(checkedSelections, [
+    {
+      model: 'claude-sonnet',
+      modelProvider: 'claude',
+      harness: 'claude-code',
+      thinkingEffort: 'medium',
+    },
+  ]);
+
+  const cleared = await validateScanRuntimeUpdate(
+    {
+      post_processing_model: null,
+      post_processing_model_provider: null,
+      post_processing_harness: null,
+    },
+    {
+      ...current,
+      configuration: {
+        post_processing_model: 'claude-sonnet',
+        post_processing_model_provider: 'claude',
+        post_processing_harness: 'claude-code',
+        post_processing_thinking_effort: 'medium',
+      },
+    },
+    { assertAvailable: async () => {} }
+  );
+
+  assert.deepEqual(cleared, {
+    postProcessingModel: null,
+    postProcessingModelProvider: null,
+    postProcessingHarness: null,
+  });
+});
+
 test('runtime scan updates validate and replace depth model overrides', async () => {
   const current = {
     model: 'gpt-5.5',

--- a/backend/test/scanPresentation.test.js
+++ b/backend/test/scanPresentation.test.js
@@ -103,7 +103,12 @@ test('scan serialization distinguishes raw candidates from listed findings', () 
       commitSha: '4a7dfc2',
       repoScope: 'full',
       dependencies: [],
-      configuration: {},
+      configuration: {
+        post_processing_model: 'gpt-5.6-sol',
+        post_processing_model_provider: 'codex',
+        post_processing_harness: 'codex',
+        post_processing_thinking_effort: 'max',
+      },
       model: 'gpt-5.4',
       modelProvider: 'codex',
       harness: 'codex',
@@ -144,6 +149,11 @@ test('scan serialization distinguishes raw candidates from listed findings', () 
   assert.deepEqual(serialized.postScriptNames, ['Ease of exploitability', 'Patched since', 'Resource exhaustion']);
   assert.equal(serialized.postScripts[0].primary, true);
   assert.deepEqual(serialized.workflowDepths, [0, 1]);
+  assert.equal(serialized.postProcessingModelOverride, true);
+  assert.equal(serialized.postProcessingModel, 'gpt-5.6-sol');
+  assert.equal(serialized.postProcessingModelProvider, 'codex');
+  assert.equal(serialized.postProcessingHarness, 'codex');
+  assert.equal(serialized.postProcessingThinkingEffort, 'max');
   assert.deepEqual(serialized.modelOverrides, {
     1: {
       model: 'claude-sonnet',

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -189,6 +189,12 @@ test('validateScan keeps post-processing thinking effort separate from workflow 
 
   assert.equal(valid.thinkingEffort, 'high');
   assert.equal(valid.postProcessingThinkingEffort, 'medium');
+  assert.deepEqual(valid.postProcessingSelection, {
+    model: 'test-model',
+    modelProvider: 'codex',
+    harness: 'codex',
+    thinkingEffort: 'medium',
+  });
   assert.equal(validateScan(base).postProcessingThinkingEffort, 'high');
   assert.throws(
     () =>
@@ -201,6 +207,21 @@ test('validateScan keeps post-processing thinking effort separate from workflow 
     (error) =>
       error instanceof ValidationError && error.errors.some((item) => item.field === 'post_processing_thinking_effort')
   );
+
+  const independent = validateScan({
+    ...base,
+    post_processing_model: 'claude-sonnet',
+    post_processing_model_provider: 'claude',
+    post_processing_harness: 'claude-code',
+    post_processing_thinking_effort: 'medium',
+  });
+  assert.equal(independent.postProcessingModelOverride, true);
+  assert.deepEqual(independent.postProcessingSelection, {
+    model: 'claude-sonnet',
+    modelProvider: 'claude',
+    harness: 'claude-code',
+    thinkingEffort: 'medium',
+  });
 });
 
 test('depth model overrides normalize complete tuples and enforce workflow depths', () => {

--- a/docs-site/first-scan/run-the-scan.mdx
+++ b/docs-site/first-scan/run-the-scan.mdx
@@ -42,7 +42,9 @@ Open **Scans → New scan** and work down the form:
     [AI provider setup](/ai-provider-setup/overview) and recreate the stack.
     Keep **One model for all depths** for the normal path. Choose **Customize by depth**
     when, for example, discovery should use a faster model and deeper investigation
-    should use a stronger one. Post-processing continues to use the default row.
+    should use a stronger one. Post-processing uses the scan model by default; choose
+    **Use different model** when final deduplication, ranking, and enrichment should run
+    with a separate model tuple.
   </Step>
   <Step title="Attach skills, post-scripts, and rankers">
     Select any agent skills, one or more post-scripts (the first is the primary), and one

--- a/docs-site/scans/create.mdx
+++ b/docs-site/scans/create.mdx
@@ -42,7 +42,8 @@ Then fill in or review each section:
   <Step title="Model and harness">
     The default [model, provider, harness, and thinking effort](/scans/model-and-harness)
     to run with. Keep one model for the whole workflow, or customize the complete tuple
-    for each workflow depth.
+    for each workflow depth. Post-processing can use the scan model or its own complete
+    model tuple.
   </Step>
   <Step title="Skills, post-scripts, rankers">
     Attach [skills](/scans/skills), [post-scripts](/scans/post-scripts), and
@@ -92,7 +93,11 @@ The create body accepts these fields:
 | `model_provider` | Yes | `codex`, `claude`, or `openrouter`. |
 | `harness` | Yes | Supported values are `codex` and `claude-code`; it must be compatible with the provider. |
 | `thinking_effort` | No | Model/harness-specific: `default`, `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`; defaults to `medium`. |
-| `model_overrides` | No | Object keyed by workflow depth. Each value is a complete `{ "model", "model_provider", "harness", "thinking_effort" }` tuple. Missing depths use the top-level tuple; post-processing always uses the top-level tuple. |
+| `post_processing_model` | No | Independent model ID for deduplication, ranking, and post-scripts. Omit it to use the top-level scan model. |
+| `post_processing_model_provider` | With `post_processing_model` | Provider for the independent post-processing model. |
+| `post_processing_harness` | With `post_processing_model` | Compatible harness for the independent post-processing model. |
+| `post_processing_thinking_effort` | No | Independent effort for post-processing. It applies to either the scan model or the independent post-processing tuple. |
+| `model_overrides` | No | Object keyed by workflow depth. Each value is a complete `{ "model", "model_provider", "harness", "thinking_effort" }` tuple. Missing depths use the top-level tuple. |
 | `jobLimit` | No | Positive whole-number cap on logical workflow and post-processing model jobs. Internal retries do not consume another job. Omit or use `null` for unlimited. |
 | `severity_ranker` | Yes | Non-empty combined Markdown ranking rules, not a ranker ID. |
 | `extra` | As required by selected prompts | Object containing every `{{extra.<key>}}` referenced by the selected workflow or post-scripts. Unknown keys are discarded. |

--- a/docs-site/scans/model-and-harness.mdx
+++ b/docs-site/scans/model-and-harness.mdx
@@ -10,7 +10,8 @@ runs your prompts and how.
 
 **One model for all depths** is the default. The provider, model, harness, and thinking
 effort selected in the main row run every workflow depth. That default tuple also runs
-deduplication, severity ranking, and post-scripts after the workflow finishes.
+deduplication, severity ranking, and post-scripts after the workflow finishes unless you
+select a separate post-processing model.
 
 Turn on **Customize by depth** when stages need different strengths or costs. The form
 creates a complete model tuple for every depth in the selected workflow. For example, a
@@ -18,12 +19,23 @@ fast model can enumerate entry points at depth 0, while a stronger model investi
 each candidate at depth 1. Sibling steps and repeat runs at the same depth use that
 depth's tuple.
 
-The main row remains the fallback and post-processing configuration. Turning customization
-off removes all depth overrides and returns the workflow to that one tuple.
+The main row remains the workflow fallback. Turning customization off removes all depth
+overrides and returns the workflow to that one tuple.
+
+## Post-processing model
+
+Post-processing uses the scan model by default, with an independently selectable thinking
+effort. Choose **Use different model** to configure a complete provider, model, harness,
+and effort tuple for deduplication, severity ranking, and every selected post-script. This
+is useful when the workflow should use a fast or economical model while final finding
+review uses a stronger one.
+
+Changing the scan model later does not change an explicit post-processing override. Switch
+back to **Use scan model** when post-processing should follow the scan default again.
 
 <Warning>
-  Every provider selected for a workflow depth can receive prompts and repository-derived
-  context from that depth. Review all configured providers before starting a scan.
+  Every provider selected for a workflow depth or post-processing can receive prompts and
+  repository-derived context. Review all configured providers before starting a scan.
 </Warning>
 
 <Note>

--- a/engine/open_kritt_engine/models.py
+++ b/engine/open_kritt_engine/models.py
@@ -53,15 +53,39 @@ def model_selection_for_depth(scan: dict[str, Any], depth: int | None = None) ->
 
 
 def post_processing_thinking_effort(scan: dict[str, Any]) -> str:
+    return post_processing_model_selection(scan).thinking_effort
+
+
+def post_processing_model_selection(scan: dict[str, Any]) -> ModelSelection:
     configuration = scan.get("configuration")
     if not isinstance(configuration, dict):
         configuration = {}
-    fallback = _selection_value(scan, "thinking_effort", "thinkingEffort", "medium")
-    return _selection_value(
-        configuration,
-        "post_processing_thinking_effort",
-        "postProcessingThinkingEffort",
-        fallback,
+    default = model_selection_for_depth(scan)
+    return ModelSelection(
+        model=_selection_value(
+            configuration,
+            "post_processing_model",
+            "postProcessingModel",
+            default.model,
+        ),
+        model_provider=_selection_value(
+            configuration,
+            "post_processing_model_provider",
+            "postProcessingModelProvider",
+            default.model_provider,
+        ),
+        harness=_selection_value(
+            configuration,
+            "post_processing_harness",
+            "postProcessingHarness",
+            default.harness,
+        ),
+        thinking_effort=_selection_value(
+            configuration,
+            "post_processing_thinking_effort",
+            "postProcessingThinkingEffort",
+            default.thinking_effort,
+        ),
     )
 
 

--- a/engine/open_kritt_engine/post_processing.py
+++ b/engine/open_kritt_engine/post_processing.py
@@ -11,10 +11,9 @@ from .harnesses import (
     RETRYABLE_RATE_LIMIT_FAILURES,
     HarnessError,
     normalize_harness_name,
-    scan_model_provider,
 )
 from .model_output_artifacts import record_model_error_output
-from .models import post_processing_thinking_effort
+from .models import post_processing_model_selection
 from .prompting import (
     append_schema_prompt,
     harness_prompt,
@@ -476,9 +475,6 @@ class PostProcessor:
         with self.db.connect() as conn:
             return self.db.load_agent_skills(conn, scan)
 
-    def _model_provider(self, scan: dict[str, Any]) -> str | None:
-        return scan_model_provider(scan)
-
     def _retry_count(self) -> int:
         return runtime_int(
             "ENGINE_RETRY_COUNT",
@@ -492,6 +488,7 @@ class PostProcessor:
         self, metadata_id: int, scan: dict[str, Any], agent_skills: list[dict[str, Any]] | None = None
     ):
         def prepare():
+            selection = post_processing_model_selection(scan)
             return prepare_dependency_workspace(
                 data_dir=self.config.data_dir,
                 checkout_cache_dir=getattr(self.config, "checkout_cache_dir", None),
@@ -499,8 +496,8 @@ class PostProcessor:
                 scan=scan,
                 github_token=self.config.github_token,
                 agent_skills=agent_skills or [],
-                harness_name=normalize_harness_name(scan["harness"]),
-                model_provider=self._model_provider(scan),
+                harness_name=normalize_harness_name(selection.harness),
+                model_provider=selection.model_provider,
                 use_snapshot_image=image_workspace_enabled(data_dir=getattr(self.config, "data_dir", None)),
             )
 
@@ -525,6 +522,7 @@ class PostProcessor:
     ) -> tuple[dict[str, Any], dict[str, Any] | None, str | None, str]:
         prepared = None
         try:
+            selection = post_processing_model_selection(scan)
             agent_skills = self._agent_skills(scan)
             prepared = self._prepare_workspace(metadata_id, scan, agent_skills=agent_skills)
             checked_out_commit = prepared.checked_out_commit
@@ -543,12 +541,12 @@ class PostProcessor:
             else:
                 prompt_body = append_schema_prompt(prompt, schema)
             prompt_parts = [
-                native_agent_skills_prompt(agent_skills, normalize_harness_name(scan["harness"])),
+                native_agent_skills_prompt(agent_skills, normalize_harness_name(selection.harness)),
                 workspace_prompt_context(prepared.layout, prepared.manifest_json),
                 prompt_body,
             ]
             final_prompt = "\n\n".join(part for part in prompt_parts if part)
-            thinking_effort = post_processing_thinking_effort(scan)
+            thinking_effort = selection.thinking_effort
             with self.db.connect() as conn:
                 self.db.update_post_process_metadata(
                     conn,
@@ -584,7 +582,7 @@ class PostProcessor:
                             "prompt": final_prompt,
                             "schema": schema,
                             "repo_dir": prepared.repo_dir,
-                            "model": scan["model"],
+                            "model": selection.model,
                             "thinking_effort": thinking_effort,
                             "env": prepared.workspace.env,
                         }
@@ -713,6 +711,7 @@ class PostProcessor:
             prompt = build_dedupe_prompt(current, anchors, targets)
             batch_index = self.db.next_post_process_batch_index(conn, scan_id, "dedupe")
             started = now_utc()
+            selection = post_processing_model_selection(current)
             metadata_id = self.db.claim_post_process_metadata(
                 conn,
                 scan_id=scan_id,
@@ -722,10 +721,10 @@ class PostProcessor:
                 target_vulnerability_ids=[_int(row["id"]) for row in targets],
                 prompt_template="anchored-dedupe",
                 prompt_filled="",
-                model=current["model"],
-                harness=current["harness"],
-                thinking_effort=post_processing_thinking_effort(current),
-                model_provider=self._model_provider(current),
+                model=selection.model,
+                harness=selection.harness,
+                thinking_effort=selection.thinking_effort,
+                model_provider=selection.model_provider,
                 run_started_at=started,
             )
             conn.commit()
@@ -754,7 +753,7 @@ class PostProcessor:
                     conn,
                     scan_id=scan_id,
                     dedupe_run_id=metadata_id,
-                    dedupe_model=current["model"],
+                    dedupe_model=selection.model,
                     mapping=mapping,
                 )
                 self.db.update_post_process_metadata(
@@ -801,6 +800,7 @@ class PostProcessor:
             prompt = build_ranker_prompt(current, anchors, targets)
             batch_index = self.db.next_post_process_batch_index(conn, scan_id, "ranker")
             started = now_utc()
+            selection = post_processing_model_selection(current)
             metadata_id = self.db.claim_post_process_metadata(
                 conn,
                 scan_id=scan_id,
@@ -810,10 +810,10 @@ class PostProcessor:
                 target_vulnerability_ids=[_int(row["id"]) for row in targets],
                 prompt_template="anchored-ranker",
                 prompt_filled="",
-                model=current["model"],
-                harness=current["harness"],
-                thinking_effort=post_processing_thinking_effort(current),
-                model_provider=self._model_provider(current),
+                model=selection.model,
+                harness=selection.harness,
+                thinking_effort=selection.thinking_effort,
+                model_provider=selection.model_provider,
                 run_started_at=started,
             )
             conn.commit()
@@ -839,7 +839,7 @@ class PostProcessor:
                 anchors=anchors,
                 targets=targets,
                 rank_run_id=metadata_id,
-                model=current["model"],
+                model=selection.model,
                 prompt_filled=prompt,
             )
             run_time_ms = int((now_utc() - started).total_seconds() * 1000)
@@ -948,6 +948,7 @@ class PostProcessor:
             if str(post_script.get("name") or "").strip().casefold() == "patched since":
                 prompt_template = patched_since_prompt(prompt_template)
             started = now_utc()
+            selection = post_processing_model_selection(current)
             metadata_id = self.db.claim_post_process_metadata(
                 conn,
                 scan_id=scan_id,
@@ -960,10 +961,10 @@ class PostProcessor:
                 target_vulnerability_ids=[_int(row["id"])],
                 prompt_template=prompt_template,
                 prompt_filled="",
-                model=current["model"],
-                harness=current["harness"],
-                thinking_effort=post_processing_thinking_effort(current),
-                model_provider=self._model_provider(current),
+                model=selection.model,
+                harness=selection.harness,
+                thinking_effort=selection.thinking_effort,
+                model_provider=selection.model_provider,
                 run_started_at=started,
             )
             conn.commit()

--- a/engine/open_kritt_engine/worker.py
+++ b/engine/open_kritt_engine/worker.py
@@ -35,7 +35,7 @@ from .harnesses import (
 )
 from .model_catalog import ModelCatalogRefresher
 from .model_output_artifacts import record_model_error_output
-from .models import ModelSelection, model_selection_for_depth
+from .models import ModelSelection, model_selection_for_depth, post_processing_model_selection
 from .post_processing import PostProcessor, PostProcessRateLimited
 from .prompting import harness_prompt, native_agent_skills_prompt, render_prompt, repeat_append_prompt
 from .provider_credentials import provider_environment
@@ -1105,7 +1105,7 @@ class Worker:
                     continue
                 if not self._worker_can_pick_job(worker_id):
                     return did_work
-                harness = self._harness_for_model_selection(model_selection_for_depth(current))
+                harness = self._harness_for_model_selection(post_processing_model_selection(current))
                 did_post_work = self.post_processor.process_once(current, harness)
                 if did_post_work:
                     return True

--- a/engine/tests/test_engine.py
+++ b/engine/tests/test_engine.py
@@ -25,11 +25,13 @@ from open_kritt_engine.harnesses import (
 )
 from open_kritt_engine.models import (
     Job,
+    ModelSelection,
     State,
     Step,
     StepResultRow,
     Workflow,
     model_selection_for_depth,
+    post_processing_model_selection,
     post_processing_thinking_effort,
 )
 from open_kritt_engine.post_processing import (
@@ -152,6 +154,30 @@ def test_post_processing_thinking_effort_is_independent_from_workflow_effort():
     assert model_selection_for_depth(configured).thinking_effort == "high"
     assert post_processing_thinking_effort(configured) == "medium"
     assert post_processing_thinking_effort({**configured, "configuration": {}}) == "high"
+
+
+def test_post_processing_can_use_a_complete_independent_model_selection():
+    configured = {
+        **scan(
+            {
+                "post_processing_model": "gpt-5-codex",
+                "post_processing_model_provider": "codex",
+                "post_processing_harness": "codex",
+                "post_processing_thinking_effort": "xhigh",
+            }
+        ),
+        "model": "claude-sonnet",
+        "model_provider": "claude",
+        "harness": "claude-code",
+        "thinking_effort": "high",
+    }
+
+    assert post_processing_model_selection(configured) == ModelSelection(
+        model="gpt-5-codex",
+        model_provider="codex",
+        harness="codex",
+        thinking_effort="xhigh",
+    )
 
 
 def fake_cache_git_head(path):
@@ -2816,14 +2842,34 @@ def test_post_processing_harness_uses_dependency_workspace(monkeypatch, tmp_path
         def update_post_process_metadata(self, _conn, metadata_id, **kwargs):
             self.updates.append({"metadata_id": metadata_id, **kwargs})
 
-    monkeypatch.setattr(post_processing_module, "prepare_dependency_workspace", lambda **_kwargs: prepared)
+    workspace_arguments = {}
+
+    def prepare_workspace(**kwargs):
+        workspace_arguments.update(kwargs)
+        return prepared
+
+    monkeypatch.setattr(post_processing_module, "prepare_dependency_workspace", prepare_workspace)
     fake_db = FakePostDb()
     processor = PostProcessor(SimpleNamespace(retry_count=0, data_dir="/tmp", github_token=None), fake_db)
     fake_harness = FakeHarness([{"ok": True}])
+    post_scan = {
+        **scan(
+            {
+                "post_processing_model": "gpt-5-codex",
+                "post_processing_model_provider": "codex",
+                "post_processing_harness": "codex",
+                "post_processing_thinking_effort": "xhigh",
+            }
+        ),
+        "model": "claude-sonnet",
+        "model_provider": "claude",
+        "harness": "claude-code",
+        "thinking_effort": "high",
+    }
 
     payload, usage, _session, checked_out_commit = processor._run_harness_with_retries(
         metadata_id=9,
-        scan=scan(),
+        scan=post_scan,
         harness=fake_harness,
         prompt="Rank findings.",
         schema={},
@@ -2834,6 +2880,10 @@ def test_post_processing_harness_uses_dependency_workspace(monkeypatch, tmp_path
     assert usage == {"total_tokens": 3}
     assert checked_out_commit == "def"
     assert fake_harness.calls[0]["repo_dir"] == "/tmp/post-repo"
+    assert fake_harness.calls[0]["model"] == "gpt-5-codex"
+    assert fake_harness.calls[0]["thinking_effort"] == "xhigh"
+    assert workspace_arguments["harness_name"] == "codex"
+    assert workspace_arguments["model_provider"] == "codex"
     assert "Workspace context:" in fake_harness.calls[0]["prompt"]
     assert fake_db.updates[0]["prompt_filled"] == fake_harness.calls[0]["prompt"]
     assert not root.exists()

--- a/frontend/src/components/WorkflowModelConfiguration.jsx
+++ b/frontend/src/components/WorkflowModelConfiguration.jsx
@@ -3,7 +3,7 @@ import ModelConfiguration, {
   modelConfigurationForCatalog,
   modelConfigurationIsValid,
 } from './ModelConfiguration.jsx';
-import { thinkingEffortForModelChange, thinkingEffortsForModel } from '../lib/modelProviders.js';
+import { thinkingEffortsForModel } from '../lib/modelProviders.js';
 import {
   enableModelOverrides,
   modelOverridesDraft,
@@ -12,21 +12,44 @@ import {
   resolvedModelConfiguration,
 } from '../lib/modelOverrides.js';
 
+function postProcessingOverrideEnabled(value = {}) {
+  return Boolean(value.post_processing_model_override ?? value.postProcessingModelOverride);
+}
+
+export function postProcessingModelConfiguration(value = {}) {
+  const override = postProcessingOverrideEnabled(value);
+  return {
+    model: override ? (value.post_processing_model ?? value.postProcessingModel ?? value.model) : value.model,
+    model_provider: override
+      ? (value.post_processing_model_provider ?? value.postProcessingModelProvider ?? value.model_provider)
+      : value.model_provider,
+    harness: override ? (value.post_processing_harness ?? value.postProcessingHarness ?? value.harness) : value.harness,
+    thinking_effort:
+      value.post_processing_thinking_effort ?? value.postProcessingThinkingEffort ?? value.thinking_effort,
+  };
+}
+
 export function workflowModelConfigurationForCatalog(current, providers, catalog) {
   const base = modelConfigurationForCatalog(current, providers, catalog);
-  const postProcessingEfforts = thinkingEffortsForModel(
-    catalog,
-    base.model_provider,
-    base.model,
-    THINKING_EFFORTS,
-    base.harness
+  const postProcessingModelOverride = postProcessingOverrideEnabled(current);
+  const postProcessing = modelConfigurationForCatalog(
+    postProcessingModelOverride
+      ? postProcessingModelConfiguration({ ...current, post_processing_model_override: true })
+      : {
+          ...base,
+          thinking_effort:
+            current?.post_processing_thinking_effort ?? current?.postProcessingThinkingEffort ?? base.thinking_effort,
+        },
+    providers,
+    catalog
   );
   return {
     ...base,
-    post_processing_thinking_effort: thinkingEffortForModelChange(
-      current?.post_processing_thinking_effort ?? current?.postProcessingThinkingEffort ?? base.thinking_effort,
-      postProcessingEfforts
-    ),
+    post_processing_model_override: postProcessingModelOverride,
+    post_processing_model: postProcessing.model,
+    post_processing_model_provider: postProcessing.model_provider,
+    post_processing_harness: postProcessing.harness,
+    post_processing_thinking_effort: postProcessing.thinking_effort,
     model_overrides: normalizeModelOverrides(current?.model_overrides ?? current?.modelOverrides, (configuration) =>
       modelConfigurationForCatalog(configuration, providers, catalog)
     ),
@@ -35,16 +58,7 @@ export function workflowModelConfigurationForCatalog(current, providers, catalog
 
 export function workflowModelConfigurationIsValid(value, depths, providers, catalog) {
   if (!modelConfigurationIsValid(value, providers, catalog)) return false;
-  const postProcessingEfforts = thinkingEffortsForModel(
-    catalog,
-    value.model_provider,
-    value.model,
-    THINKING_EFFORTS,
-    value.harness
-  );
-  const postProcessingThinkingEffort =
-    value?.post_processing_thinking_effort ?? value?.postProcessingThinkingEffort ?? value?.thinking_effort;
-  if (!postProcessingEfforts.includes(postProcessingThinkingEffort)) return false;
+  if (!modelConfigurationIsValid(postProcessingModelConfiguration(value), providers, catalog)) return false;
   const overrides = modelOverridesDraft(value?.model_overrides ?? value?.modelOverrides);
   const allowedDepths = new Set(depths.map(String));
   if (Object.keys(overrides).some((depth) => !allowedDepths.has(depth))) return false;
@@ -81,15 +95,15 @@ export default function WorkflowModelConfiguration({
   const customized = Object.keys(overrides).length > 0;
   const canCustomize = depths.length > 0;
   const depthLabels = new Map(depthChips.map((chip) => [chip.depth, chip]));
+  const postProcessingModelOverride = postProcessingOverrideEnabled(value);
+  const postProcessingConfiguration = postProcessingModelConfiguration(value);
   const postProcessingEfforts = thinkingEffortsForModel(
     catalog,
-    value.model_provider,
-    value.model,
+    postProcessingConfiguration.model_provider,
+    postProcessingConfiguration.model,
     THINKING_EFFORTS,
-    value.harness
+    postProcessingConfiguration.harness
   );
-  const postProcessingThinkingEffort =
-    value?.post_processing_thinking_effort ?? value?.postProcessingThinkingEffort ?? value?.thinking_effort;
 
   const useSingleModel = () => onChange({ ...value, model_overrides: {} });
   const customizeByDepth = () =>
@@ -148,10 +162,8 @@ export default function WorkflowModelConfiguration({
         />
       </div>
 
-      <label
+      <div
         style={{
-          display: 'block',
-          maxWidth: 280,
           marginTop: 12,
           border: '1px solid var(--border)',
           borderRadius: 9,
@@ -160,30 +172,97 @@ export default function WorkflowModelConfiguration({
         }}
       >
         <span className="mono" style={{ display: 'block', fontSize: 10.5, color: 'var(--text-3)', marginBottom: 7 }}>
-          POST-PROCESSING THINKING EFFORT
+          POST-PROCESSING MODEL
         </span>
-        <select
-          className="mono"
-          value={postProcessingThinkingEffort}
-          disabled={disabled || postProcessingEfforts.length === 0}
-          onChange={(event) => onChange({ ...value, post_processing_thinking_effort: event.target.value })}
-          style={{
-            width: '100%',
-            height: 36,
-            padding: '0 10px',
-            borderRadius: 7,
-            border: '1px solid var(--border)',
-            background: 'var(--surface)',
-            color: 'var(--text)',
-          }}
+        <div
+          role="group"
+          aria-label="Post-processing model strategy"
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}
         >
-          {postProcessingEfforts.map((effort) => (
-            <option key={effort} value={effort}>
-              {effort}
-            </option>
-          ))}
-        </select>
-      </label>
+          <button
+            type="button"
+            aria-pressed={!postProcessingModelOverride}
+            disabled={disabled}
+            onClick={() =>
+              onChange({
+                ...value,
+                post_processing_model_override: false,
+                post_processing_model: value.model,
+                post_processing_model_provider: value.model_provider,
+                post_processing_harness: value.harness,
+              })
+            }
+            style={modeButtonStyle(!postProcessingModelOverride, disabled)}
+          >
+            Use scan model
+          </button>
+          <button
+            type="button"
+            aria-pressed={postProcessingModelOverride}
+            disabled={disabled}
+            onClick={() =>
+              onChange({
+                ...value,
+                post_processing_model_override: true,
+                post_processing_model: postProcessingConfiguration.model,
+                post_processing_model_provider: postProcessingConfiguration.model_provider,
+                post_processing_harness: postProcessingConfiguration.harness,
+              })
+            }
+            style={modeButtonStyle(postProcessingModelOverride, disabled)}
+          >
+            Use different model
+          </button>
+        </div>
+
+        {postProcessingModelOverride ? (
+          <ModelConfiguration
+            value={postProcessingConfiguration}
+            onChange={(configuration) =>
+              onChange({
+                ...value,
+                post_processing_model_override: true,
+                post_processing_model: configuration.model,
+                post_processing_model_provider: configuration.model_provider,
+                post_processing_harness: configuration.harness,
+                post_processing_thinking_effort: configuration.thinking_effort,
+              })
+            }
+            providers={providers}
+            catalog={catalog}
+            catalogError={catalogError}
+            disabled={disabled}
+            showAvailabilityHelp={false}
+          />
+        ) : (
+          <label style={{ display: 'block', maxWidth: 280 }}>
+            <span className="mono" style={{ display: 'block', fontSize: 10, color: 'var(--text-3)', marginBottom: 6 }}>
+              THINKING EFFORT
+            </span>
+            <select
+              className="mono"
+              value={postProcessingConfiguration.thinking_effort}
+              disabled={disabled || postProcessingEfforts.length === 0}
+              onChange={(event) => onChange({ ...value, post_processing_thinking_effort: event.target.value })}
+              style={{
+                width: '100%',
+                height: 36,
+                padding: '0 10px',
+                borderRadius: 7,
+                border: '1px solid var(--border)',
+                background: 'var(--surface)',
+                color: 'var(--text)',
+              }}
+            >
+              {postProcessingEfforts.map((effort) => (
+                <option key={effort} value={effort}>
+                  {effort}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
 
       {customized && (
         <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>

--- a/frontend/src/components/WorkflowModelConfiguration.test.jsx
+++ b/frontend/src/components/WorkflowModelConfiguration.test.jsx
@@ -34,7 +34,11 @@ const configured = {
   model_provider: 'codex',
   harness: 'codex',
   thinking_effort: 'high',
-  post_processing_thinking_effort: 'high',
+  post_processing_model_override: true,
+  post_processing_model: 'claude-sonnet',
+  post_processing_model_provider: 'claude',
+  post_processing_harness: 'claude-code',
+  post_processing_thinking_effort: 'medium',
   model_overrides: {
     0: {
       model: 'gpt-5-codex',
@@ -97,7 +101,9 @@ describe('WorkflowModelConfiguration', () => {
     expect(html).toContain('One model for all depths');
     expect(html).toContain('Customize by depth');
     expect(html).toContain('DEFAULT WORKFLOW MODEL');
-    expect(html).toContain('POST-PROCESSING THINKING EFFORT');
+    expect(html).toContain('POST-PROCESSING MODEL');
+    expect(html).toContain('Use scan model');
+    expect(html).toContain('Use different model');
     expect(html).toContain('DEPTH 0');
     expect(html).toContain('DEPTH 1');
     expect(html).toContain('2 steps');

--- a/frontend/src/lib/scanDuplication.js
+++ b/frontend/src/lib/scanDuplication.js
@@ -7,6 +7,12 @@ const CONFIGURATION_RELATION_KEYS = [
   'agent_skills',
   'post_processing_thinking_effort',
   'postProcessingThinkingEffort',
+  'post_processing_model',
+  'postProcessingModel',
+  'post_processing_model_provider',
+  'postProcessingModelProvider',
+  'post_processing_harness',
+  'postProcessingHarness',
 ];
 
 function uniqueIds(values) {
@@ -75,6 +81,10 @@ export function scanConfigurationDraft(scan) {
     model_provider: `${scan.modelProvider ?? ''}`,
     harness: `${scan.harness ?? ''}`,
     thinking_effort: `${scan.thinkingEffort ?? ''}`,
+    post_processing_model_override: Boolean(scan.postProcessingModelOverride),
+    post_processing_model: `${scan.postProcessingModel ?? scan.model ?? ''}`,
+    post_processing_model_provider: `${scan.postProcessingModelProvider ?? scan.modelProvider ?? ''}`,
+    post_processing_harness: `${scan.postProcessingHarness ?? scan.harness ?? ''}`,
     post_processing_thinking_effort: `${scan.postProcessingThinkingEffort ?? scan.thinkingEffort ?? ''}`,
     model_overrides: modelOverridesDraft(scan.modelOverrides),
     extra: duplicateExtra(scan.extra),

--- a/frontend/src/lib/scanDuplication.test.js
+++ b/frontend/src/lib/scanDuplication.test.js
@@ -25,12 +25,19 @@ describe('scanConfigurationDraft', () => {
         include_tests: true,
         post_script_ids: ['21', '22'],
         agent_skill_ids: ['31', '32'],
+        post_processing_model: 'gpt-5.6-sol',
+        post_processing_model_provider: 'codex',
+        post_processing_harness: 'codex',
         post_processing_thinking_effort: 'medium',
       },
       model: 'gpt-5.4',
       modelProvider: 'codex',
       harness: 'codex',
       thinkingEffort: 'high',
+      postProcessingModelOverride: true,
+      postProcessingModel: 'gpt-5.6-sol',
+      postProcessingModelProvider: 'codex',
+      postProcessingHarness: 'codex',
       postProcessingThinkingEffort: 'medium',
       modelOverrides: {
         1: {
@@ -70,6 +77,10 @@ describe('scanConfigurationDraft', () => {
       model_provider: 'codex',
       harness: 'codex',
       thinking_effort: 'high',
+      post_processing_model_override: true,
+      post_processing_model: 'gpt-5.6-sol',
+      post_processing_model_provider: 'codex',
+      post_processing_harness: 'codex',
       post_processing_thinking_effort: 'medium',
       model_overrides: {
         1: {

--- a/frontend/src/pages/CreateScan.jsx
+++ b/frontend/src/pages/CreateScan.jsx
@@ -99,6 +99,10 @@ export default function CreateScan() {
     model_provider: '',
     harness: '',
     thinking_effort: 'medium',
+    post_processing_model_override: false,
+    post_processing_model: '',
+    post_processing_model_provider: '',
+    post_processing_harness: '',
     post_processing_thinking_effort: 'medium',
     model_overrides: {},
     extra: {},
@@ -322,6 +326,10 @@ export default function CreateScan() {
         normalized.model === f.model &&
         normalized.model_provider === f.model_provider &&
         normalized.thinking_effort === f.thinking_effort &&
+        normalized.post_processing_model_override === f.post_processing_model_override &&
+        normalized.post_processing_model === f.post_processing_model &&
+        normalized.post_processing_model_provider === f.post_processing_model_provider &&
+        normalized.post_processing_harness === f.post_processing_harness &&
         normalized.post_processing_thinking_effort === f.post_processing_thinking_effort &&
         normalized.harness === f.harness &&
         modelOverridesEqual(normalized.model_overrides, f.model_overrides)
@@ -521,6 +529,13 @@ export default function CreateScan() {
       model_provider: form.model_provider,
       harness: form.harness,
       thinking_effort: form.thinking_effort,
+      ...(form.post_processing_model_override
+        ? {
+            post_processing_model: form.post_processing_model,
+            post_processing_model_provider: form.post_processing_model_provider,
+            post_processing_harness: form.post_processing_harness,
+          }
+        : {}),
       post_processing_thinking_effort: form.post_processing_thinking_effort,
       model_overrides: form.model_overrides,
       severity_ranker: combinedRanker,

--- a/frontend/src/pages/ScanDetail.jsx
+++ b/frontend/src/pages/ScanDetail.jsx
@@ -1070,8 +1070,11 @@ function ScanRunSettings({
           <RuntimeSetting label="model" value={current.model} />
           <RuntimeSetting label="model_provider" value={current.model_provider || '—'} />
           <RuntimeSetting label="thinking_effort" value={current.thinking_effort || '—'} />
-          <RuntimeSetting label="post-processing effort" value={current.post_processing_thinking_effort || '—'} />
           <RuntimeSetting label="harness" value={current.harness} />
+          <RuntimeSetting label="post model" value={current.post_processing_model || '—'} />
+          <RuntimeSetting label="post provider" value={current.post_processing_model_provider || '—'} />
+          <RuntimeSetting label="post effort" value={current.post_processing_thinking_effort || '—'} />
+          <RuntimeSetting label="post harness" value={current.post_processing_harness || '—'} />
           <RuntimeSetting label="depth overrides" value={Object.keys(current.model_overrides).length || 'none'} />
           <RuntimeSetting
             label="model jobs"
@@ -1088,6 +1091,10 @@ export function runSettingsDraft(scan = {}) {
     model: scan.model || '',
     model_provider: scan.modelProvider || 'openrouter',
     thinking_effort: scan.thinkingEffort || 'medium',
+    post_processing_model_override: Boolean(scan.postProcessingModelOverride),
+    post_processing_model: scan.postProcessingModel || scan.model || '',
+    post_processing_model_provider: scan.postProcessingModelProvider || scan.modelProvider || 'openrouter',
+    post_processing_harness: scan.postProcessingHarness || scan.harness || 'codex',
     post_processing_thinking_effort: scan.postProcessingThinkingEffort || scan.thinkingEffort || 'medium',
     harness: scan.harness || 'codex',
     model_overrides: modelOverridesDraft(scan.modelOverrides),
@@ -1103,10 +1110,21 @@ function runSettingsValue(value, fallback) {
 
 export function mergeRunSettingsDraft(current = {}, patch = {}) {
   const hasModelOverrides = Object.prototype.hasOwnProperty.call(patch || {}, 'model_overrides');
+  const hasPostProcessingModelOverride = Object.prototype.hasOwnProperty.call(
+    patch || {},
+    'post_processing_model_override'
+  );
   const base = {
     model: runSettingsValue(current?.model, ''),
     model_provider: runSettingsValue(current?.model_provider, 'openrouter'),
     thinking_effort: runSettingsValue(current?.thinking_effort, 'medium'),
+    post_processing_model_override: Boolean(current?.post_processing_model_override),
+    post_processing_model: runSettingsValue(current?.post_processing_model, current?.model || ''),
+    post_processing_model_provider: runSettingsValue(
+      current?.post_processing_model_provider,
+      current?.model_provider || 'openrouter'
+    ),
+    post_processing_harness: runSettingsValue(current?.post_processing_harness, current?.harness || 'codex'),
     post_processing_thinking_effort: runSettingsValue(
       current?.post_processing_thinking_effort,
       current?.thinking_effort || 'medium'
@@ -1119,6 +1137,15 @@ export function mergeRunSettingsDraft(current = {}, patch = {}) {
     model: runSettingsValue(patch?.model, base.model),
     model_provider: runSettingsValue(patch?.model_provider, base.model_provider),
     thinking_effort: runSettingsValue(patch?.thinking_effort, base.thinking_effort),
+    post_processing_model_override: hasPostProcessingModelOverride
+      ? Boolean(patch.post_processing_model_override)
+      : base.post_processing_model_override,
+    post_processing_model: runSettingsValue(patch?.post_processing_model, base.post_processing_model),
+    post_processing_model_provider: runSettingsValue(
+      patch?.post_processing_model_provider,
+      base.post_processing_model_provider
+    ),
+    post_processing_harness: runSettingsValue(patch?.post_processing_harness, base.post_processing_harness),
     post_processing_thinking_effort: runSettingsValue(
       patch?.post_processing_thinking_effort,
       base.post_processing_thinking_effort
@@ -1140,6 +1167,21 @@ export function runSettingsPayload(draft, current) {
     payload.model_provider = normalizedDraft.model_provider;
   if (normalizedDraft.thinking_effort !== normalizedCurrent.thinking_effort)
     payload.thinking_effort = normalizedDraft.thinking_effort;
+  const postProcessingModelChanged =
+    normalizedDraft.post_processing_model !== normalizedCurrent.post_processing_model ||
+    normalizedDraft.post_processing_model_provider !== normalizedCurrent.post_processing_model_provider ||
+    normalizedDraft.post_processing_harness !== normalizedCurrent.post_processing_harness;
+  if (normalizedDraft.post_processing_model_override) {
+    if (!normalizedCurrent.post_processing_model_override || postProcessingModelChanged) {
+      payload.post_processing_model = normalizedDraft.post_processing_model.trim();
+      payload.post_processing_model_provider = normalizedDraft.post_processing_model_provider;
+      payload.post_processing_harness = normalizedDraft.post_processing_harness;
+    }
+  } else if (normalizedCurrent.post_processing_model_override) {
+    payload.post_processing_model = null;
+    payload.post_processing_model_provider = null;
+    payload.post_processing_harness = null;
+  }
   if (normalizedDraft.post_processing_thinking_effort !== normalizedCurrent.post_processing_thinking_effort)
     payload.post_processing_thinking_effort = normalizedDraft.post_processing_thinking_effort;
   if (normalizedDraft.harness !== normalizedCurrent.harness) payload.harness = normalizedDraft.harness;

--- a/frontend/src/pages/ScanDetail.test.jsx
+++ b/frontend/src/pages/ScanDetail.test.jsx
@@ -42,6 +42,10 @@ describe('scan run settings', () => {
     model: 'gpt-5-codex',
     model_provider: 'codex',
     thinking_effort: 'medium',
+    post_processing_model_override: false,
+    post_processing_model: 'gpt-5-codex',
+    post_processing_model_provider: 'codex',
+    post_processing_harness: 'codex',
     post_processing_thinking_effort: 'low',
     harness: 'codex',
     model_overrides: {},
@@ -53,6 +57,10 @@ describe('scan run settings', () => {
       model: 'gpt-5-codex',
       model_provider: 'codex',
       thinking_effort: 'medium',
+      post_processing_model_override: false,
+      post_processing_model: 'gpt-5-codex',
+      post_processing_model_provider: 'codex',
+      post_processing_harness: 'codex',
       post_processing_thinking_effort: 'low',
       harness: 'codex',
     };
@@ -66,6 +74,10 @@ describe('scan run settings', () => {
       model: 'legacy-model',
       model_provider: 'openrouter',
       thinking_effort: 'medium',
+      post_processing_model_override: false,
+      post_processing_model: 'legacy-model',
+      post_processing_model_provider: 'openrouter',
+      post_processing_harness: 'codex',
       post_processing_thinking_effort: 'medium',
       harness: 'codex',
       model_overrides: {},
@@ -85,6 +97,43 @@ describe('scan run settings', () => {
   it('updates post-processing effort independently', () => {
     expect(runSettingsPayload({ post_processing_thinking_effort: 'medium' }, current)).toEqual({
       post_processing_thinking_effort: 'medium',
+    });
+  });
+
+  it('sets and clears an independent post-processing model selection', () => {
+    expect(
+      runSettingsPayload(
+        {
+          post_processing_model_override: true,
+          post_processing_model: 'claude-sonnet',
+          post_processing_model_provider: 'claude',
+          post_processing_harness: 'claude-code',
+          post_processing_thinking_effort: 'high',
+        },
+        current
+      )
+    ).toEqual({
+      post_processing_model: 'claude-sonnet',
+      post_processing_model_provider: 'claude',
+      post_processing_harness: 'claude-code',
+      post_processing_thinking_effort: 'high',
+    });
+
+    expect(
+      runSettingsPayload(
+        { post_processing_model_override: false },
+        {
+          ...current,
+          post_processing_model_override: true,
+          post_processing_model: 'claude-sonnet',
+          post_processing_model_provider: 'claude',
+          post_processing_harness: 'claude-code',
+        }
+      )
+    ).toEqual({
+      post_processing_model: null,
+      post_processing_model_provider: null,
+      post_processing_harness: null,
     });
   });
 


### PR DESCRIPTION
## What changed

- let scans use the default workflow model or a complete independent model/provider/harness tuple for post-processing
- apply that selection consistently to deduplication, severity ranking, and post-scripts
- validate model availability and provider/harness compatibility at creation and runtime edits
- persist the override in scan configuration and preserve it when duplicating scans
- expose the selection in scan details and allow it to be enabled, changed, or cleared from the UI
- record the actual post-processing runtime in metadata and use its provider workspace/credentials
- document the UI and API fields

## Why

Workflow discovery and final finding review often have different cost and capability needs. A scan can now use an economical model across workflow depths and reserve a stronger model for deduplication, ranking, reports, and PoCs, without changing existing scans that rely on the scan model plus an independent post-processing effort.

## Validation

- `frontend: npm run lint`
- `frontend: npm test` (216 tests)
- `frontend: npm run build`
- `backend: npm run lint`
- `backend: npm test` (154 tests)
- `engine: ruff format --check` / `ruff check` for changed files
- `engine: pytest -q tests/test_engine.py`
- `docs-site: node check-links.mjs`
- targeted Prettier checks and `git diff --check`
