### PR TITLE
fix(backend): validate scan resource ids

### DIFF
--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -649,6 +649,32 @@ export function validateScanJobLimit(value, field = 'jobLimit') {
   return limit;
 }
 
+const MAX_DATABASE_ID = 9_223_372_036_854_775_807n;
+
+function validateDatabaseId(value, field, label, push) {
+  if (value === undefined || value === null || (typeof value === 'string' && !value.trim())) {
+    push(field, `${label} is required.`);
+    return null;
+  }
+
+  let text = '';
+  if (typeof value === 'string') text = value.trim();
+  else if (typeof value === 'number' && Number.isSafeInteger(value)) text = `${value}`;
+  else if (typeof value === 'bigint') text = value.toString();
+
+  if (!/^\d+$/.test(text)) {
+    push(field, `${label} must be a positive integer ID.`);
+    return null;
+  }
+
+  const id = BigInt(text);
+  if (id < 1n || id > MAX_DATABASE_ID) {
+    push(field, `${label} must be a positive integer ID.`);
+    return null;
+  }
+  return id.toString();
+}
+
 // Normalize + validate a single repo reference (the scan target or a dependency).
 // `localNames` is a Set of available local repo folder names (or null to skip the
 // existence check). Pushes precise field errors under `prefix`.
@@ -680,12 +706,13 @@ export function validateScan(body, { localNames = null } = {}) {
   const errors = [];
   const push = (field, message) => errors.push({ field, message });
 
-  const workflowId = body?.workflowId ?? body?.workflow_id;
-  if (workflowId === undefined || workflowId === null || `${workflowId}`.trim() === '')
-    push('workflowId', 'A workflow is required.');
-  const postScriptId = body?.postScriptId ?? body?.post_script_id;
-  if (postScriptId === undefined || postScriptId === null || `${postScriptId}`.trim() === '')
-    push('postScriptId', 'A post-script is required.');
+  const workflowId = validateDatabaseId(body?.workflowId ?? body?.workflow_id, 'workflowId', 'A workflow', push);
+  const postScriptId = validateDatabaseId(
+    body?.postScriptId ?? body?.post_script_id,
+    'postScriptId',
+    'A post-script',
+    push
+  );
   let jobLimit = null;
   try {
     jobLimit = validateScanJobLimit(body?.jobLimit ?? body?.job_limit);

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -463,6 +463,46 @@ test('validateScan requires a non-empty severity ranker', () => {
   assert.equal(v.severityRanker, 'A\n\nB');
 });
 
+test('validateScan requires workflow and post-script ids to be positive database ids', () => {
+  const base = {
+    workflowId: '1',
+    postScriptId: '1',
+    repo_kind: 'remote',
+    repo_full: 'https://github.com/org/repo',
+    commit_sha: 'HEAD',
+    model: 'gpt-5.5',
+    harness: 'codex',
+    severity_ranker: 'Rank by impact.',
+  };
+
+  assert.equal(validateScan({ ...base, workflowId: '0002', postScriptId: 3 }).workflowId, '2');
+  assert.equal(validateScan({ ...base, workflowId: '0002', postScriptId: 3 }).postScriptId, '3');
+
+  for (const [field, value] of [
+    ['workflowId', true],
+    ['workflowId', '1.5'],
+    ['workflowId', '-1'],
+    ['workflowId', '0'],
+    ['workflowId', {}],
+    ['workflowId', '9223372036854775808'],
+    ['postScriptId', false],
+    ['postScriptId', '1.5'],
+    ['postScriptId', '-1'],
+    ['postScriptId', '0'],
+    ['postScriptId', {}],
+    ['postScriptId', '9223372036854775808'],
+  ]) {
+    assert.throws(
+      () => validateScan({ ...base, [field]: value }),
+      (error) =>
+        error instanceof ValidationError &&
+        error.errors.some(
+          (item) => item.field === field && item.message.includes('must be a positive integer ID')
+        )
+    );
+  }
+});
+
 test('validateScan labels local repository contents as a snapshot, not a Git revision', () => {
   const valid = validateScan(
     {


### PR DESCRIPTION
## Summary

- Validate `workflowId` and `postScriptId` as positive database IDs in `validateScan`.
- Normalize accepted IDs to decimal strings before route-level `BigInt(...)` conversion.
- Add regression coverage for booleans, objects, decimals, zero, negatives, oversized IDs, and leading-zero valid IDs.

## Root cause

The scan validator previously only checked that IDs were non-empty. That allowed malformed body values to reach `BigInt(...)` in the scan route.

## Validation

```bash
cd backend && node --test test/validation.test.js test/templateRefs.test.js
```

Closes #44
