### PR TITLE
fix(backend): reject duplicate output format keys

### DIFF
--- a/backend/src/lib/constants.js
+++ b/backend/src/lib/constants.js
@@ -291,3 +291,25 @@ export function normalizeOutputFormat(input) {
   }
   return out;
 }
+
+export function duplicateOutputFormatKeys(input) {
+  let value = input;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const field of value) {
+    if (!field || typeof field !== 'object' || !('key' in field) || !field.key) continue;
+    const key = `${field.key}`;
+    if (seen.has(key)) duplicates.add(key);
+    else seen.add(key);
+  }
+  return [...duplicates];
+}

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -32,6 +32,7 @@ import {
   hasMalformedTemplateRefs,
   parseRefs,
   normalizeOutputFormat,
+  duplicateOutputFormatKeys,
   refResolves,
   extractExtraKeys,
   multiOutputDepthKey,
@@ -216,6 +217,9 @@ export function validateWorkflow(body) {
     let outputFormat = {};
     try {
       outputFormat = normalizeOutputFormat(lvl?.outputFormat ?? {});
+      for (const key of duplicateOutputFormatKeys(lvl?.outputFormat ?? {})) {
+        push(`levels[${i}].outputFormat`, `"${key}" is used more than once in this output format.`);
+      }
     } catch {
       push(`levels[${i}].outputFormat`, 'Output format is not valid JSON.');
     }
@@ -391,6 +395,9 @@ export function validatePostScript(body) {
   let outputFormat = {};
   try {
     outputFormat = normalizeOutputFormat(body?.outputFormat ?? {});
+    for (const key of duplicateOutputFormatKeys(body?.outputFormat ?? {})) {
+      push('outputFormat', `"${key}" is a duplicate output key.`);
+    }
   } catch {
     push('outputFormat', 'Output format is not valid JSON.');
   }

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -283,6 +283,25 @@ test('validateWorkflow enforces canonical terminal vulnerability field types', (
   }
 });
 
+test('validateWorkflow rejects duplicate output keys before array formats are normalized', () => {
+  const outputFormat = [
+    ...Object.entries(terminalOutput).map(([key, type]) => ({ key, type })),
+    { key: 'confidence', type: 'string' },
+    { key: 'confidence', type: 'number' },
+  ];
+
+  assert.throws(
+    () => validateWorkflow(workflowWithTerminal(outputFormat)),
+    (error) =>
+      error instanceof ValidationError &&
+      error.errors.some(
+        (item) =>
+          item.field === 'levels[0].outputFormat' &&
+          item.message === '"confidence" is used more than once in this output format.'
+      )
+  );
+});
+
 test('validateWorkflow clears individual ancestor keys at a consumesAll boundary', () => {
   const workflow = {
     name: 'batched-workflow',
@@ -366,6 +385,22 @@ test('validatePostScript enforces reserved output conventions', () => {
       outputFormat: { _reserved_report: 'string', _reserved_poc: 'string', _chip_severity: 'string' },
     }).outputFormat,
     { _reserved_report: 'string', _reserved_poc: 'string', _chip_severity: 'string' }
+  );
+});
+
+test('validatePostScript rejects duplicate output keys before array formats are normalized', () => {
+  const outputFormat = JSON.stringify([
+    { key: '_chip_risk', type: 'string' },
+    { key: '_chip_risk', type: 'string' },
+  ]);
+
+  assert.throws(
+    () => validatePostScript({ name: 'duplicate-output', content: 'Analyze {{summary}}.', outputFormat }),
+    (error) =>
+      error instanceof ValidationError &&
+      error.errors.some(
+        (item) => item.field === 'outputFormat' && item.message === '"_chip_risk" is a duplicate output key.'
+      )
   );
 });
 


### PR DESCRIPTION
## Summary

- Add duplicate-key detection for array-form `outputFormat` values before normalization.
- Reject duplicate workflow output keys with a validation error.
- Reject duplicate post-script output keys with a validation error.
- Add regression tests for array and JSON-string array input.

## Root cause

`normalizeOutputFormat` converted `{ key, type }[]` into an object map before validator duplicate checks ran, so later rows overwrote earlier rows.

## Validation

```bash
cd backend && node --test test/validation.test.js test/templateRefs.test.js
```

Closes #45
