### PR TITLE
fix: use current Codex max threads setting

### DIFF
--- a/engine/open_kritt_engine/harnesses.py
+++ b/engine/open_kritt_engine/harnesses.py
@@ -1373,7 +1373,7 @@ def codex_exec_command(
     if allow_tools:
         command.append("--dangerously-bypass-approvals-and-sandbox")
         if max_subagents is not None:
-            command.extend(["-c", f"agents.max_concurrent_threads_per_session={max_subagents}"])
+            command.extend(["-c", f"agents.max_threads={max_subagents}"])
     else:
         command.extend(
             [
@@ -1571,7 +1571,7 @@ class CodexHarness:
             model,
             "--dangerously-bypass-approvals-and-sandbox",
             "-c",
-            f"agents.max_concurrent_threads_per_session={self.max_subagents}",
+            f"agents.max_threads={self.max_subagents}",
             "-o",
             output_path,
         ]

--- a/engine/tests/test_engine.py
+++ b/engine/tests/test_engine.py
@@ -937,7 +937,7 @@ def test_codex_harness_uses_dangerous_permissions_and_web_search(monkeypatch):
     assert result.payload == marked({"stub": True, "stub_explanation": "No matching records.", "results": []})
     assert captured["cmd"][:3] == ["codex", "--search", "exec"]
     assert "--dangerously-bypass-approvals-and-sandbox" in captured["cmd"]
-    assert "agents.max_concurrent_threads_per_session=5" in captured["cmd"]
+    assert "agents.max_threads=5" in captured["cmd"]
     assert "--ephemeral" not in captured["cmd"]
     assert "--sandbox" not in captured["cmd"]
 
@@ -1172,7 +1172,7 @@ def test_codex_harness_resumes_corrupted_session_for_json(monkeypatch, tmp_path)
     assert result.usage["total_tokens"] == 7
     assert calls[1][:3] == ["codex", "exec", "resume"]
     assert calls[1][-2:] == ["session-bad", "-"]
-    assert "agents.max_concurrent_threads_per_session=5" in calls[1]
+    assert "agents.max_threads=5" in calls[1]
     assert 'model_provider="openrouter"' in calls[1]
     assert 'model_reasoning_effort="medium"' in calls[1]
     assert EXTRACTOR_HELPER_FIELD in prompts[1]

--- a/engine/tests/test_generation.py
+++ b/engine/tests/test_generation.py
@@ -509,7 +509,7 @@ def test_tool_free_codex_command_disables_search_and_execution_features():
     assert not any(value.startswith("model_provider=") for value in tool_free)
     assert "--search" in scan_mode
     assert "--dangerously-bypass-approvals-and-sandbox" in scan_mode
-    assert "agents.max_concurrent_threads_per_session=5" in scan_mode
+    assert "agents.max_threads=5" in scan_mode
     assert not any(value.startswith("model_provider=") for value in scan_mode)
 
     provider_default = codex_exec_command(


### PR DESCRIPTION
## What & why

Codex CLI rejects the obsolete `agents.max_concurrent_threads_per_session` config key. Use the current `agents.max_threads` key in both fresh and resumed Codex command construction, and update the command-shape regressions.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [x] `test`
- [ ] Breaking change

## Affected components

- [x] engine

## Verification

- full engine suite: 293 passed
- focused Codex command regressions: 3 passed
- `ruff check` on changed files: pass
- `ruff format --check` on changed files: pass
- `git diff --check`: pass

The repository currently pins `psycopg[binary]==3.3.4`, which was unavailable from the configured package index. The full suite used Python 3.11 with `psycopg[binary]==3.2.13`; pytest remained at the pinned 9.1.1. No dependency file is changed by this PR.

## Checklist

- [x] Conventional Commit
- [x] DCO signed off
- [x] Tests updated and passing
- [x] No secrets committed