### PR TITLE
feat: append vulnerability comments atomically

### DIFF
--- a/backend/src/routes/vulnerabilities.js
+++ b/backend/src/routes/vulnerabilities.js
@@ -91,16 +91,17 @@ router.patch('/:id', async (req, res, next) => {
         return tx.vulnerability.update({
           where: { id },
           data: patch.data,
-          select: { id: true, interesting: true, comments: true },
+          select: { id: true, scanId: true, interesting: true, comments: true },
         });
       }
       return tx.vulnerability.findUnique({
         where: { id },
-        select: { id: true, interesting: true, comments: true },
+        select: { id: true, scanId: true, interesting: true, comments: true },
       });
     });
     res.json({
       id: updated.id.toString(),
+      scanId: updated.scanId.toString(),
       interesting:
         updated.interesting === null || updated.interesting === undefined ? null : Number(updated.interesting),
       comments: updated.comments ?? null,

--- a/backend/src/routes/vulnerabilities.js
+++ b/backend/src/routes/vulnerabilities.js
@@ -4,6 +4,36 @@ import { serializeVulnerability } from '../lib/serialize.js';
 
 const router = Router();
 
+export function buildVulnerabilityPatch(body = {}) {
+  const data = {};
+  let appendComments;
+  if ('interesting' in body) {
+    const val = body.interesting;
+    if (val === null) data.interesting = null;
+    else if (val === 0 || val === 1 || val === '0' || val === '1') data.interesting = BigInt(Number(val));
+    else return { error: { field: 'interesting', message: 'interesting must be 0, 1, or null.' } };
+  }
+  if ('comments' in body && 'appendComments' in body) {
+    return { error: { field: 'comments', message: 'comments and appendComments are mutually exclusive.' } };
+  }
+  if ('comments' in body) {
+    data.comments = body.comments === null || body.comments === '' ? null : String(body.comments);
+  }
+  if ('appendComments' in body) {
+    if (typeof body.appendComments !== 'string' || !body.appendComments.trim()) {
+      return { error: { field: 'appendComments', message: 'appendComments must be a non-empty string.' } };
+    }
+    if (Buffer.byteLength(body.appendComments, 'utf8') > 64 * 1024) {
+      return { error: { field: 'appendComments', message: 'appendComments must not exceed 64 KiB.' } };
+    }
+    appendComments = body.appendComments;
+  }
+  if (Object.keys(data).length === 0 && appendComments === undefined) {
+    return { error: { field: 'body', message: 'Provide interesting, comments, and/or appendComments.' } };
+  }
+  return { data, appendComments };
+}
+
 // GET /api/vulnerabilities/:id — a single finding with its post-script output.
 router.get('/:id', async (req, res, next) => {
   try {
@@ -31,34 +61,43 @@ router.get('/:id', async (req, res, next) => {
 
 // PATCH /api/vulnerabilities/:id — user review: interesting flag and/or comments.
 // interesting: 1 (interesting), 0 (not interesting), or null (unmarked).
+// appendComments: atomically append a non-empty marker once without overwriting concurrent comments.
 router.patch('/:id', async (req, res, next) => {
   try {
     const id = BigInt(req.params.id);
     const existing = await prisma.vulnerability.findUnique({ where: { id }, select: { id: true } });
     if (!existing) return res.status(404).json({ error: 'Vulnerability not found.' });
 
-    const body = req.body || {};
-    const data = {};
-    if ('interesting' in body) {
-      const val = body.interesting;
-      if (val === null) data.interesting = null;
-      else if (val === 0 || val === 1 || val === '0' || val === '1') data.interesting = BigInt(Number(val));
-      else
-        return res
-          .status(422)
-          .json({ errors: [{ field: 'interesting', message: 'interesting must be 0, 1, or null.' }] });
-    }
-    if ('comments' in body) {
-      data.comments = body.comments === null || body.comments === '' ? null : String(body.comments);
-    }
-    if (Object.keys(data).length === 0) {
-      return res.status(422).json({ errors: [{ field: 'body', message: 'Provide interesting and/or comments.' }] });
+    const patch = buildVulnerabilityPatch(req.body || {});
+    if (patch.error) {
+      return res.status(422).json({ errors: [patch.error] });
     }
 
-    const updated = await prisma.vulnerability.update({
-      where: { id },
-      data,
-      select: { id: true, interesting: true, comments: true },
+    const updated = await prisma.$transaction(async (tx) => {
+      if (patch.appendComments !== undefined) {
+        await tx.$executeRaw`
+          UPDATE "workflows"."vulnerabilities"
+          SET
+            "comments" = CASE
+              WHEN "comments" IS NULL OR "comments" = '' THEN ${patch.appendComments}
+              WHEN POSITION(${patch.appendComments} IN "comments") > 0 THEN "comments"
+              ELSE "comments" || E'\n\n' || ${patch.appendComments}
+            END,
+            "updated_at" = NOW()
+          WHERE "id" = ${id}
+        `;
+      }
+      if (Object.keys(patch.data).length > 0) {
+        return tx.vulnerability.update({
+          where: { id },
+          data: patch.data,
+          select: { id: true, interesting: true, comments: true },
+        });
+      }
+      return tx.vulnerability.findUnique({
+        where: { id },
+        select: { id: true, interesting: true, comments: true },
+      });
     });
     res.json({
       id: updated.id.toString(),

--- a/backend/test/vulnerabilityComments.test.js
+++ b/backend/test/vulnerabilityComments.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildVulnerabilityPatch } from '../src/routes/vulnerabilities.js';
+
+test('vulnerability patches normalize the existing replace fields', () => {
+  assert.deepEqual(buildVulnerabilityPatch({ interesting: '1', comments: 'reviewed' }), {
+    data: { interesting: 1n, comments: 'reviewed' },
+    appendComments: undefined,
+  });
+  assert.deepEqual(buildVulnerabilityPatch({ interesting: null, comments: '' }), {
+    data: { interesting: null, comments: null },
+    appendComments: undefined,
+  });
+});
+
+test('appendComments is bounded and mutually exclusive with replacement', () => {
+  assert.deepEqual(buildVulnerabilityPatch({ appendComments: '[cvuln reverse export digest]' }), {
+    data: {},
+    appendComments: '[cvuln reverse export digest]',
+  });
+  assert.equal(buildVulnerabilityPatch({ appendComments: '' }).error.field, 'appendComments');
+  assert.equal(buildVulnerabilityPatch({ comments: 'old', appendComments: 'new' }).error.field, 'comments');
+  assert.equal(buildVulnerabilityPatch({ appendComments: 'x'.repeat(64 * 1024 + 1) }).error.field, 'appendComments');
+});
+
+test('unknown-only and invalid interesting patches fail closed', () => {
+  assert.equal(buildVulnerabilityPatch({ unknown: true }).error.field, 'body');
+  assert.equal(buildVulnerabilityPatch({ interesting: 2 }).error.field, 'interesting');
+});


### PR DESCRIPTION
## What & why

Add an `appendComments` vulnerability PATCH field for external verification/control-plane markers. The append is performed inside a database transaction with duplicate-marker suppression, so concurrent clients cannot overwrite an existing user comment or append the same marker twice.

The PATCH response now returns both vulnerability `id` and immutable `scanId`, allowing clients to fail closed if a record belongs to the wrong scan.

`appendComments` is bounded to 64 KiB, must be non-empty, and is mutually exclusive with the existing replacement-style `comments` field.

This supports the fail-closed cvuln reverse-export client in mitrilmad/cvuln#3.

## Tests

- `npm test` — 156 passed
- `npm run lint` — pass
- `npm run format:check` — pass
- deployed local compose backend; atomic append returned vulnerability 1 / scan 2; repeated cvuln apply was idempotent with live marker count 1

## Type of change

- [x] New feature
- [x] Security hardening

## Contributor checklist

- [x] I have tested the change locally
- [x] I ran tests for the affected component
- [x] No secrets or credentials are included
- [x] Commit includes DCO sign-off