### PR TITLE
feat(frontend): add privacy-safe sharing loop

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,10 +1,13 @@
+import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar.jsx';
 import Topbar from './Topbar.jsx';
+import ShareResultDialog from './ShareResultDialog.jsx';
 import { useTheme } from '../context/ui.jsx';
 
 export default function Layout() {
   const { theme } = useTheme();
+  const [communityShareOpen, setCommunityShareOpen] = useState(false);
   return (
     <div
       className="app-shell"
@@ -20,7 +23,8 @@ export default function Layout() {
         fontSize: 14,
       }}
     >
-      <Sidebar />
+      <Sidebar onShareCommunity={() => setCommunityShareOpen(true)} />
+      {communityShareOpen && <ShareResultDialog mode="community" onClose={() => setCommunityShareOpen(false)} />}
       <div className="app-main" style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
         <Topbar />
         <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', position: 'relative' }}>

--- a/frontend/src/components/ShareResultDialog.jsx
+++ b/frontend/src/components/ShareResultDialog.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Button } from './ui.jsx';
+import { useModalDialog } from '../lib/useModalDialog.js';
+import {
+  SHARE_CARD_HEIGHT,
+  SHARE_CARD_WIDTH,
+  SHARE_IMAGE_FILENAME,
+  buildCommunityShareArtifact,
+  buildShareArtifact,
+  canvasToPngBlob,
+  copyShareText,
+  downloadShareBlob,
+  renderShareCard,
+  shareWithChannel,
+} from '../lib/shareResult.js';
+
+function shareFile(blob) {
+  if (!blob || typeof File === 'undefined') return null;
+  return new File([blob], SHARE_IMAGE_FILENAME, { type: 'image/png' });
+}
+
+export default function ShareResultDialog({ severity = null, automatic = false, mode = 'result', onClose }) {
+  const communityMode = mode === 'community';
+  const [includeSeverity, setIncludeSeverity] = useState(false);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  const [imageBlob, setImageBlob] = useState(null);
+  const [imageError, setImageError] = useState(null);
+  const [busyAction, setBusyAction] = useState(null);
+  const [feedback, setFeedback] = useState(null);
+  const canvasRef = useRef(null);
+
+  const closeDialog = () => onClose({ disableAutomaticPrompts: automatic && dontShowAgain });
+  const dialogRef = useModalDialog(closeDialog);
+  const cardArtifact = useMemo(
+    () => (communityMode ? buildCommunityShareArtifact() : buildShareArtifact({ includeSeverity, severity })),
+    [communityMode, includeSeverity, severity]
+  );
+  const xArtifact = useMemo(
+    () =>
+      communityMode
+        ? buildCommunityShareArtifact({ channel: 'x' })
+        : buildShareArtifact({ includeSeverity, severity, channel: 'x' }),
+    [communityMode, includeSeverity, severity]
+  );
+  const elsewhereArtifact = useMemo(
+    () =>
+      communityMode
+        ? buildCommunityShareArtifact({ channel: 'elsewhere' })
+        : buildShareArtifact({ includeSeverity, severity, channel: 'elsewhere' }),
+    [communityMode, includeSeverity, severity]
+  );
+
+  useEffect(() => {
+    let active = true;
+    setImageBlob(null);
+    setImageError(null);
+    setFeedback(null);
+    Promise.resolve()
+      .then(() => renderShareCard(canvasRef.current, cardArtifact))
+      .then(() => canvasToPngBlob(canvasRef.current))
+      .then((blob) => {
+        if (active) setImageBlob(blob);
+      })
+      .catch((error) => {
+        if (active) setImageError(error);
+      });
+    return () => {
+      active = false;
+    };
+  }, [cardArtifact]);
+
+  const runAction = async (name, action) => {
+    if (!imageBlob || busyAction) return;
+    setBusyAction(name);
+    setFeedback(null);
+    try {
+      await action();
+    } catch (error) {
+      if (error?.name !== 'AbortError') {
+        setFeedback({ tone: 'error', message: error?.message || 'Sharing failed. Please try again.' });
+      }
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const shareOnX = () =>
+    runAction('x', async () => {
+      const result = await shareWithChannel({
+        artifact: xArtifact,
+        file: shareFile(imageBlob),
+        blob: imageBlob,
+      });
+      setFeedback(
+        result.kind === 'x-fallback'
+          ? {
+              tone: 'success',
+              message: 'The PNG was downloaded. Attach it to the prefilled X post that just opened.',
+            }
+          : { tone: 'success', message: 'The X-ready image and @Kritt_AI caption were sent to your share sheet.' }
+      );
+    });
+
+  const shareElsewhere = () =>
+    runAction('elsewhere', async () => {
+      const result = await shareWithChannel({
+        artifact: elsewhereArtifact,
+        file: shareFile(imageBlob),
+        blob: imageBlob,
+      });
+      if (result.kind === 'unsupported') {
+        await copyShareText(elsewhereArtifact.caption);
+        setFeedback({
+          tone: 'success',
+          message: 'Native sharing is unavailable, so the GitHub-linked post was copied instead.',
+        });
+      } else if (result.kind === 'text-shared') {
+        setFeedback({
+          tone: 'success',
+          message: 'The GitHub-linked post was sent to your share sheet. You can download the PNG separately.',
+        });
+      } else {
+        setFeedback({ tone: 'success', message: 'The image and GitHub-linked post were sent to your share sheet.' });
+      }
+    });
+
+  const copyPost = () =>
+    runAction('copy', async () => {
+      await copyShareText(elsewhereArtifact.caption);
+      setFeedback({ tone: 'success', message: 'Post copied with the open·kritt GitHub link.' });
+    });
+
+  const downloadImage = () =>
+    runAction('download', async () => {
+      downloadShareBlob(imageBlob);
+      setFeedback({ tone: 'success', message: 'PNG downloaded.' });
+    });
+
+  const imageReady = Boolean(imageBlob) && !imageError;
+
+  return (
+    <div className="share-result-backdrop" role="presentation" onMouseDown={closeDialog}>
+      <div
+        ref={dialogRef}
+        className="share-result-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-result-title"
+        tabIndex={-1}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="share-result-header">
+          <div>
+            <div id="share-result-title" className="share-result-title">
+              It’s open source. Give back to the community.
+            </div>
+            <div className="share-result-subtitle">
+              {communityMode
+                ? 'Help more security researchers discover, use, and improve open·kritt.'
+                : 'Share what open·kritt helped you accomplish—never the classified vulnerability details.'}
+            </div>
+          </div>
+          <button type="button" className="share-result-close" aria-label="Close share dialog" onClick={closeDialog}>
+            ×
+          </button>
+        </div>
+
+        <div className="share-result-body">
+          <canvas
+            ref={canvasRef}
+            className="share-result-preview"
+            width={SHARE_CARD_WIDTH}
+            height={SHARE_CARD_HEIGHT}
+            role="img"
+            aria-label={`Share-card preview: ${cardArtifact.cardText}`}
+          />
+
+          {!communityMode && severity && (
+            <label className="share-result-option">
+              <input
+                type="checkbox"
+                checked={includeSeverity}
+                onChange={(event) => setIncludeSeverity(event.target.checked)}
+              />
+              <span>
+                <strong>Include highest severity</strong>
+                <small>This reveals only the normalized severity shown in the preview.</small>
+              </span>
+            </label>
+          )}
+
+          <div className="share-result-privacy-note">
+            {communityMode ? (
+              <>This shares only open·kritt branding and project links. No scan or vulnerability data is included.</>
+            ) : (
+              <>
+                No repository, finding title, path, code, report, PoC, model, scan ID, count, or timestamp is included.
+                Sharing open·kritt—not the vulnerability details—is the safe way to contribute back.
+              </>
+            )}
+          </div>
+
+          {imageError && (
+            <div className="share-result-feedback share-result-feedback-error" role="alert">
+              {imageError.message}
+            </div>
+          )}
+          {feedback && (
+            <div
+              className={`share-result-feedback ${
+                feedback.tone === 'error' ? 'share-result-feedback-error' : 'share-result-feedback-success'
+              }`}
+              role={feedback.tone === 'error' ? 'alert' : 'status'}
+              aria-live="polite"
+            >
+              {feedback.message}
+            </div>
+          )}
+
+          <div className="share-result-actions">
+            <div className="share-result-channel-actions">
+              <Button data-autofocus disabled={!imageReady || Boolean(busyAction)} onClick={shareOnX}>
+                {busyAction === 'x' ? 'Sharing…' : 'Share on X'}
+              </Button>
+              <Button variant="subtle" disabled={!imageReady || Boolean(busyAction)} onClick={shareElsewhere}>
+                {busyAction === 'elsewhere' ? 'Sharing…' : 'Share elsewhere'}
+              </Button>
+            </div>
+            <div className="share-result-secondary-actions">
+              <Button variant="ghost" disabled={!imageReady || Boolean(busyAction)} onClick={copyPost}>
+                {busyAction === 'copy' ? 'Copying…' : 'Copy post'}
+              </Button>
+              <Button variant="ghost" disabled={!imageReady || Boolean(busyAction)} onClick={downloadImage}>
+                {busyAction === 'download' ? 'Downloading…' : 'Download PNG'}
+              </Button>
+            </div>
+          </div>
+
+          {!communityMode && automatic && (
+            <label className="share-result-dont-show">
+              <input
+                type="checkbox"
+                checked={dontShowAgain}
+                onChange={(event) => setDontShowAgain(event.target.checked)}
+              />
+              Don’t show this automatically again
+            </label>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ShareResultDialog.test.jsx
+++ b/frontend/src/components/ShareResultDialog.test.jsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import ShareResultDialog from './ShareResultDialog.jsx';
+
+describe('ShareResultDialog', () => {
+  it('renders the branded privacy controls and automatic-prompt opt-out', () => {
+    const html = renderToStaticMarkup(<ShareResultDialog severity="critical" automatic onClose={() => {}} />);
+
+    expect(html).toContain('It’s open source. Give back to the community.');
+    expect(html).toContain('Share-card preview: I found a vulnerability using open·kritt.');
+    expect(html).toContain('width="1200"');
+    expect(html).toContain('height="630"');
+    expect(html).toContain('Include highest severity');
+    expect(html).toContain('Share on X');
+    expect(html).toContain('Share elsewhere');
+    expect(html).toContain('Don’t show this automatically again');
+    expect(html).toContain('No repository, finding title, path, code, report, PoC');
+  });
+
+  it('renders a project-focused community sharing prompt without scan controls', () => {
+    const html = renderToStaticMarkup(<ShareResultDialog mode="community" onClose={() => {}} />);
+
+    expect(html).toContain('It’s open source. Give back to the community.');
+    expect(html).toContain('Open-source security is stronger when we build together.');
+    expect(html).toContain('No scan or vulnerability data is included.');
+    expect(html).not.toContain('Include highest severity');
+    expect(html).not.toContain('Don’t show this automatically again');
+  });
+
+  it('keeps the severity control and automatic opt-out out when unavailable or manually opened', () => {
+    const html = renderToStaticMarkup(<ShareResultDialog onClose={() => {}} />);
+
+    expect(html).not.toContain('Include highest severity');
+    expect(html).not.toContain('Don’t show this automatically again');
+    expect(html).toContain('Copy post');
+    expect(html).toContain('Download PNG');
+  });
+});

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -71,7 +71,17 @@ export function CommunityLinks() {
   );
 }
 
-export default function Sidebar() {
+export function CommunityShareButton({ onClick }) {
+  return (
+    <button type="button" className="sidebar-community-share" onClick={onClick}>
+      <span className="sidebar-community-share-long">Give back to the community by sharing</span>
+      <span className="sidebar-community-share-short">Share open·kritt</span>
+      <span aria-hidden="true">↗</span>
+    </button>
+  );
+}
+
+export default function Sidebar({ onShareCommunity }) {
   const { pathname } = useLocation();
   const { theme, toggle } = useTheme();
 
@@ -157,6 +167,7 @@ export default function Sidebar() {
         <div className="mono sidebar-community-label" style={GROUP_LABEL}>
           COMMUNITY
         </div>
+        <CommunityShareButton onClick={onShareCommunity} />
         <CommunityLinks />
       </div>
 

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
-import { CommunityLinks } from './Sidebar.jsx';
+import { CommunityLinks, CommunityShareButton } from './Sidebar.jsx';
 
 describe('sidebar community links', () => {
   it('renders every project and contact destination', () => {
@@ -14,5 +14,13 @@ describe('sidebar community links', () => {
     expect(html).toContain('href="mailto:info@kritt.ai"');
     expect(html.match(/target="_blank"/g)).toHaveLength(4);
     expect(html.match(/rel="noreferrer"/g)).toHaveLength(4);
+  });
+
+  it('renders the persistent community sharing call to action', () => {
+    const html = renderToStaticMarkup(<CommunityShareButton onClick={() => {}} />);
+
+    expect(html).toContain('Give back to the community by sharing');
+    expect(html).toContain('Share open·kritt');
+    expect(html).toContain('type="button"');
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -154,6 +154,41 @@ a {
   padding-bottom: 7px;
 }
 
+.sidebar-community-share {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 10px 11px;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
+  border-radius: 9px;
+  background: var(--accent-subtle);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.3;
+  text-align: left;
+}
+
+.sidebar-community-share:hover,
+.sidebar-community-share:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.sidebar-community-share:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sidebar-community-share-short {
+  display: none;
+}
+
 .sidebar-community-links {
   display: flex;
   flex-wrap: wrap;
@@ -1118,6 +1153,224 @@ a {
   align-items: center;
 }
 
+.share-result-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.share-result-dialog {
+  width: min(760px, 100%);
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
+}
+
+.share-result-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 20px 22px 18px;
+  border-bottom: 1px solid var(--border-2);
+}
+
+.share-result-title {
+  max-width: 620px;
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+}
+
+.share-result-subtitle {
+  max-width: 620px;
+  margin-top: 9px;
+  color: var(--text-2);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.share-result-close {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.share-result-close:hover,
+.share-result-close:focus-visible {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.share-result-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.share-result-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 22px;
+}
+
+.share-result-preview {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1200 / 630;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: #fbfbfa;
+  box-shadow: var(--shadow);
+}
+
+.share-result-option,
+.share-result-dont-show {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  color: var(--text-2);
+  cursor: pointer;
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.share-result-option input,
+.share-result-dont-show input {
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.share-result-option span {
+  display: grid;
+  gap: 2px;
+}
+
+.share-result-option strong {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.share-result-option small {
+  color: var(--text-3);
+  font-size: 11.5px;
+}
+
+.share-result-privacy-note {
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.share-result-feedback {
+  padding: 9px 11px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.share-result-feedback-success {
+  background: var(--ok-bg);
+  color: var(--ok);
+}
+
+.share-result-feedback-error {
+  background: var(--fail-bg);
+  color: var(--fail);
+}
+
+.share-result-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 2px;
+}
+
+.share-result-channel-actions,
+.share-result-secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.share-result-dont-show {
+  padding-top: 12px;
+  border-top: 1px solid var(--border-2);
+}
+
+@media (max-width: 700px) {
+  .scan-detail-heading {
+    flex-direction: column;
+  }
+
+  .scan-detail-actions {
+    width: 100%;
+    justify-content: flex-start !important;
+  }
+
+  .share-result-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .share-result-dialog {
+    width: 100%;
+    max-height: 94vh;
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 15px 15px 0 0;
+  }
+
+  .share-result-header,
+  .share-result-body {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .share-result-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .share-result-channel-actions,
+  .share-result-secondary-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .share-result-channel-actions button,
+  .share-result-secondary-actions button {
+    justify-content: center;
+    min-width: 0;
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+}
+
 @media (max-width: 860px) {
   .scan-results-grid {
     grid-template-columns: 1fr;
@@ -1205,6 +1458,19 @@ a {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 2px;
+  }
+
+  .sidebar-community-share {
+    margin-bottom: 3px;
+    padding: 7px 9px;
+  }
+
+  .sidebar-community-share-long {
+    display: none;
+  }
+
+  .sidebar-community-share-short {
+    display: inline;
   }
 
   .sidebar-community-link {

--- a/frontend/src/lib/shareResult.js
+++ b/frontend/src/lib/shareResult.js
@@ -1,0 +1,378 @@
+export const SHARE_CARD_WIDTH = 1200;
+export const SHARE_CARD_HEIGHT = 630;
+export const SHARE_IMAGE_FILENAME = 'open-kritt-security-finding.png';
+export const X_HANDLE = '@Kritt_AI';
+export const X_DESTINATION = 'https://kritt.ai/';
+export const GITHUB_DESTINATION = 'https://github.com/Kritt-ai/open-kritt';
+
+const SHARE_PROMPT_SETTINGS_KEY = 'ok-share-prompt-v1';
+const SHARE_PROMPT_SCAN_PREFIX = `${SHARE_PROMPT_SETTINGS_KEY}:scan:`;
+const SHARE_PROMPT_RATE = 0.2;
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low'];
+const SEVERITY_LABELS = Object.fromEntries(SEVERITY_ORDER.map((severity) => [severity, capitalize(severity)]));
+
+function capitalize(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function normalizeShareSeverity(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return Object.hasOwn(SEVERITY_LABELS, normalized) ? normalized : null;
+}
+
+export function highestShareSeverity(values) {
+  const normalized = new Set((Array.isArray(values) ? values : []).map(normalizeShareSeverity).filter(Boolean));
+  return SEVERITY_ORDER.find((severity) => normalized.has(severity)) || null;
+}
+
+export function buildShareArtifact({ channel = 'elsewhere', includeSeverity = false, severity = null } = {}) {
+  const safeChannel = channel === 'x' ? 'x' : 'elsewhere';
+  const safeSeverity = includeSeverity ? normalizeShareSeverity(severity) : null;
+  const qualifier = safeSeverity ? `${SEVERITY_LABELS[safeSeverity]} ` : '';
+  const cardText = `I found a ${qualifier}vulnerability using open·kritt.`;
+  const caption =
+    safeChannel === 'x'
+      ? `${cardText} Built with ${X_HANDLE}.\n\n${X_DESTINATION}`
+      : `${cardText}\n\nOpen source: ${GITHUB_DESTINATION}`;
+
+  return Object.freeze({
+    channel: safeChannel,
+    severity: safeSeverity,
+    cardText,
+    caption,
+  });
+}
+
+export function buildCommunityShareArtifact({ channel = 'elsewhere' } = {}) {
+  const safeChannel = channel === 'x' ? 'x' : 'elsewhere';
+  const cardText = 'Open-source security is stronger when we build together.';
+  const caption =
+    safeChannel === 'x'
+      ? `Open-source security is stronger when we build together. Support ${X_HANDLE} and share open·kritt.\n\n${X_DESTINATION}`
+      : `Open-source security is stronger when we build together. Support and share open·kritt.\n\n${GITHUB_DESTINATION}`;
+
+  return Object.freeze({
+    channel: safeChannel,
+    severity: null,
+    cardText,
+    caption,
+  });
+}
+
+export function canShareScanResult({ status, findingsLoaded, findingCount }) {
+  return status === 'completed' && findingsLoaded === true && Number(findingCount) > 0;
+}
+
+function parseSettings(value) {
+  if (!value) return { firstEligibleSeen: false, disabled: false };
+  try {
+    const parsed = JSON.parse(value);
+    return {
+      firstEligibleSeen: parsed?.firstEligibleSeen === true,
+      disabled: parsed?.disabled === true,
+    };
+  } catch {
+    return { firstEligibleSeen: false, disabled: false };
+  }
+}
+
+function browserStorage() {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function createSharePromptStore(storage = browserStorage()) {
+  let activeStorage = storage;
+  let memorySettings = { firstEligibleSeen: false, disabled: false };
+  const memoryDecisions = new Map();
+
+  const readSettings = () => {
+    if (!activeStorage) return memorySettings;
+    try {
+      memorySettings = parseSettings(activeStorage.getItem(SHARE_PROMPT_SETTINGS_KEY));
+    } catch {
+      activeStorage = null;
+    }
+    return memorySettings;
+  };
+
+  const writeSettings = (settings) => {
+    memorySettings = settings;
+    if (!activeStorage) return;
+    try {
+      activeStorage.setItem(SHARE_PROMPT_SETTINGS_KEY, JSON.stringify(settings));
+    } catch {
+      activeStorage = null;
+    }
+  };
+
+  const readDecision = (scanId) => {
+    const key = String(scanId);
+    if (memoryDecisions.has(key)) return memoryDecisions.get(key);
+    if (!activeStorage) return null;
+    try {
+      const value = activeStorage.getItem(`${SHARE_PROMPT_SCAN_PREFIX}${key}`);
+      if (value === 'shown' || value === 'skipped') {
+        memoryDecisions.set(key, value);
+        return value;
+      }
+    } catch {
+      activeStorage = null;
+    }
+    return null;
+  };
+
+  const writeDecision = (scanId, decision) => {
+    const key = String(scanId);
+    memoryDecisions.set(key, decision);
+    if (!activeStorage) return;
+    try {
+      activeStorage.setItem(`${SHARE_PROMPT_SCAN_PREFIX}${key}`, decision);
+    } catch {
+      activeStorage = null;
+    }
+  };
+
+  return {
+    evaluate({ scanId, status, findingsLoaded, findingCount, random = Math.random }) {
+      if (!canShareScanResult({ status, findingsLoaded, findingCount })) return false;
+      const settings = readSettings();
+      if (settings.disabled || readDecision(scanId)) return false;
+
+      const shouldShow = !settings.firstEligibleSeen || random() < SHARE_PROMPT_RATE;
+      writeDecision(scanId, shouldShow ? 'shown' : 'skipped');
+      writeSettings({ ...settings, firstEligibleSeen: true });
+      return shouldShow;
+    },
+
+    disableAutomaticPrompts() {
+      writeSettings({ ...readSettings(), disabled: true });
+    },
+
+    automaticPromptsDisabled() {
+      return readSettings().disabled;
+    },
+  };
+}
+
+export const sharePromptStore = createSharePromptStore();
+
+let logoPromise = null;
+
+function loadShareLogo() {
+  if (logoPromise) return logoPromise;
+  logoPromise = new Promise((resolve, reject) => {
+    if (typeof Image === 'undefined') {
+      reject(new Error('Image generation is unavailable in this browser.'));
+      return;
+    }
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('The open·kritt logo could not be loaded.'));
+    image.src = '/apple-touch-icon.png';
+  });
+  return logoPromise;
+}
+
+function roundedRect(context, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.arcTo(x + width, y, x + width, y + height, r);
+  context.arcTo(x + width, y + height, x, y + height, r);
+  context.arcTo(x, y + height, x, y, r);
+  context.arcTo(x, y, x + width, y, r);
+  context.closePath();
+}
+
+function wrapCanvasText(context, text, x, y, maxWidth, lineHeight) {
+  const words = text.split(/\s+/);
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word;
+    if (line && context.measureText(next).width > maxWidth) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = next;
+    }
+  }
+  if (line) lines.push(line);
+  lines.forEach((value, index) => context.fillText(value, x, y + index * lineHeight));
+  return lines.length;
+}
+
+export async function renderShareCard(canvas, artifact) {
+  const context = canvas?.getContext?.('2d');
+  if (!context) throw new Error('Image generation is unavailable in this browser.');
+  const logo = await loadShareLogo();
+
+  canvas.width = SHARE_CARD_WIDTH;
+  canvas.height = SHARE_CARD_HEIGHT;
+
+  const gradient = context.createLinearGradient(0, 0, SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT);
+  gradient.addColorStop(0, '#fffaf7');
+  gradient.addColorStop(1, '#f6f5f2');
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT);
+
+  context.fillStyle = '#ff5c3d';
+  context.beginPath();
+  context.arc(1138, 56, 190, 0, Math.PI * 2);
+  context.fill();
+  context.globalAlpha = 0.12;
+  context.beginPath();
+  context.arc(1088, 602, 255, 0, Math.PI * 2);
+  context.fill();
+  context.globalAlpha = 1;
+
+  context.save();
+  roundedRect(context, 64, 48, 112, 112, 24);
+  context.clip();
+  context.drawImage(logo, 64, 48, 112, 112);
+  context.restore();
+
+  context.fillStyle = '#1a1a18';
+  context.font = "600 43px 'Geist', Arial, sans-serif";
+  context.textBaseline = 'alphabetic';
+  context.fillText('open', 198, 118);
+  const openWidth = context.measureText('open').width;
+  context.fillStyle = '#ff5c3d';
+  context.fillText('·', 198 + openWidth, 118);
+  const dotWidth = context.measureText('·').width;
+  context.fillStyle = '#1a1a18';
+  context.fillText('kritt', 198 + openWidth + dotWidth, 118);
+
+  context.fillStyle = '#1a1a18';
+  context.font = "700 66px 'Geist', Arial, sans-serif";
+  const lineCount = wrapCanvasText(context, artifact.cardText, 70, 276, 1015, 82);
+
+  const supportingY = 276 + lineCount * 82 + 34;
+  context.fillStyle = '#6b6b66';
+  context.font = "400 27px 'Geist', Arial, sans-serif";
+  context.fillText('AI-driven security research. Open source.', 72, Math.min(supportingY, 488));
+
+  context.strokeStyle = '#deddd9';
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(72, 542);
+  context.lineTo(1128, 542);
+  context.stroke();
+
+  context.fillStyle = '#fff0ec';
+  roundedRect(context, 72, 565, 166, 36, 18);
+  context.fill();
+  context.fillStyle = '#d74228';
+  context.font = "700 16px 'Geist', Arial, sans-serif";
+  context.fillText('OPEN SOURCE', 91, 589);
+
+  context.fillStyle = '#6b6b66';
+  context.font = "500 21px 'Geist', Arial, sans-serif";
+  context.textAlign = 'right';
+  context.fillText('kritt.ai', 1128, 590);
+  context.textAlign = 'left';
+}
+
+export function canvasToPngBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('The share image could not be generated.'));
+    }, 'image/png');
+  });
+}
+
+export function xIntentUrl(caption) {
+  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(caption)}`;
+}
+
+function canShareFile(navigatorObject, file) {
+  if (!file || typeof navigatorObject?.share !== 'function' || typeof navigatorObject?.canShare !== 'function') {
+    return false;
+  }
+  try {
+    return navigatorObject.canShare({ files: [file] }) === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function shareWithChannel({
+  artifact,
+  file,
+  blob = file,
+  navigatorObject = globalThis.navigator,
+  downloadFile = downloadShareBlob,
+  openWindow = (url) => globalThis.window?.open?.(url, '_blank', 'noopener,noreferrer'),
+}) {
+  // The Web Share API cannot target a specific app. If we use it for X, Chrome
+  // may open the operating-system share sheet without X as an available target.
+  // Open the composer directly and download the image for manual attachment so
+  // this action behaves consistently across browsers and operating systems.
+  if (artifact.channel === 'x') {
+    openWindow(xIntentUrl(artifact.caption));
+    downloadFile(blob, SHARE_IMAGE_FILENAME);
+    return { kind: 'x-fallback' };
+  }
+
+  if (canShareFile(navigatorObject, file)) {
+    await navigatorObject.share({
+      title: 'open·kritt security finding',
+      text: artifact.caption,
+      files: [file],
+    });
+    return { kind: 'file-shared' };
+  }
+
+  if (typeof navigatorObject?.share === 'function') {
+    await navigatorObject.share({
+      title: 'open·kritt security finding',
+      text: artifact.caption,
+    });
+    return { kind: 'text-shared' };
+  }
+
+  return { kind: 'unsupported' };
+}
+
+export function downloadShareBlob(blob, filename = SHARE_IMAGE_FILENAME) {
+  if (!blob) throw new Error('The share image is not ready yet.');
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export async function copyShareText(
+  text,
+  { navigatorObject = globalThis.navigator, documentObject = globalThis.document } = {}
+) {
+  if (typeof navigatorObject?.clipboard?.writeText === 'function') {
+    await navigatorObject.clipboard.writeText(text);
+    return;
+  }
+  if (!documentObject?.body || typeof documentObject.execCommand !== 'function') {
+    throw new Error('Clipboard access is unavailable in this browser.');
+  }
+
+  const textarea = documentObject.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  documentObject.body.appendChild(textarea);
+  textarea.select();
+  const copied = documentObject.execCommand('copy');
+  textarea.remove();
+  if (!copied) throw new Error('The post could not be copied.');
+}

--- a/frontend/src/lib/shareResult.test.js
+++ b/frontend/src/lib/shareResult.test.js
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GITHUB_DESTINATION,
+  X_DESTINATION,
+  X_HANDLE,
+  buildCommunityShareArtifact,
+  buildShareArtifact,
+  canShareScanResult,
+  copyShareText,
+  createSharePromptStore,
+  highestShareSeverity,
+  normalizeShareSeverity,
+  shareWithChannel,
+  xIntentUrl,
+} from './shareResult.js';
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+  };
+}
+
+const eligible = (scanId, random = () => 0.99) => ({
+  scanId,
+  status: 'completed',
+  findingsLoaded: true,
+  findingCount: 1,
+  random,
+});
+
+describe('share artifact privacy', () => {
+  it('defaults to generic copy and keeps channel attribution separate', () => {
+    const x = buildShareArtifact({ channel: 'x' });
+    const elsewhere = buildShareArtifact({ channel: 'elsewhere' });
+
+    expect(x.cardText).toBe('I found a vulnerability using open·kritt.');
+    expect(x.caption).toContain(X_HANDLE);
+    expect(x.caption).toContain(X_DESTINATION);
+    expect(x.caption).not.toContain(GITHUB_DESTINATION);
+
+    expect(elsewhere.caption).toContain(GITHUB_DESTINATION);
+    expect(elsewhere.caption).not.toContain(X_HANDLE);
+    expect(elsewhere.caption).not.toContain(X_DESTINATION);
+  });
+
+  it('allows only recognized normalized severities into the card', () => {
+    expect(normalizeShareSeverity(' Critical ')).toBe('critical');
+    expect(normalizeShareSeverity('informational')).toBeNull();
+    expect(highestShareSeverity(['low', 'Critical', 'high'])).toBe('critical');
+
+    expect(buildShareArtifact({ includeSeverity: true, severity: 'high' }).cardText).toContain('a High vulnerability');
+    const unsafe = buildShareArtifact({
+      includeSeverity: true,
+      severity: 'Critical — secret/repository src/auth.js',
+      repoFull: 'secret/repository',
+      summary: 'private finding',
+    });
+    expect(unsafe.cardText).toBe('I found a vulnerability using open·kritt.');
+    expect(JSON.stringify(unsafe)).not.toContain('secret');
+    expect(JSON.stringify(unsafe)).not.toContain('private');
+  });
+
+  it('builds a scan-free community artifact with channel-specific attribution', () => {
+    const x = buildCommunityShareArtifact({ channel: 'x' });
+    const elsewhere = buildCommunityShareArtifact({ channel: 'elsewhere' });
+
+    expect(x.cardText).toContain('Open-source security');
+    expect(x.caption).toContain(X_HANDLE);
+    expect(x.caption).toContain(X_DESTINATION);
+    expect(x.caption).not.toContain(GITHUB_DESTINATION);
+    expect(elsewhere.caption).toContain(GITHUB_DESTINATION);
+    expect(elsewhere.caption).not.toContain(X_HANDLE);
+  });
+});
+
+describe('share prompt eligibility and frequency', () => {
+  it('requires a completed scan with loaded canonical findings', () => {
+    expect(canShareScanResult({ status: 'completed', findingsLoaded: true, findingCount: 1 })).toBe(true);
+    expect(canShareScanResult({ status: 'running', findingsLoaded: true, findingCount: 1 })).toBe(false);
+    expect(canShareScanResult({ status: 'completed', findingsLoaded: false, findingCount: 1 })).toBe(false);
+    expect(canShareScanResult({ status: 'completed', findingsLoaded: true, findingCount: 0 })).toBe(false);
+  });
+
+  it('always shows the first eligible scan, then draws once per later scan', () => {
+    const store = createSharePromptStore(memoryStorage());
+    const firstRandom = vi.fn(() => 0.99);
+
+    expect(store.evaluate(eligible('1', firstRandom))).toBe(true);
+    expect(firstRandom).not.toHaveBeenCalled();
+    expect(store.evaluate(eligible('1', () => 0))).toBe(false);
+    expect(store.evaluate(eligible('2', () => 0.19))).toBe(true);
+    expect(store.evaluate(eligible('2', () => 0.99))).toBe(false);
+    expect(store.evaluate(eligible('3', () => 0.2))).toBe(false);
+    expect(store.evaluate(eligible('3', () => 0))).toBe(false);
+  });
+
+  it('does not consume the first decision for ineligible scans and supports global dismissal', () => {
+    const store = createSharePromptStore(memoryStorage());
+    expect(
+      store.evaluate({ scanId: '0', status: 'completed', findingsLoaded: true, findingCount: 0, random: () => 0 })
+    ).toBe(false);
+    expect(store.evaluate(eligible('1'))).toBe(true);
+
+    store.disableAutomaticPrompts();
+    expect(store.automaticPromptsDisabled()).toBe(true);
+    expect(store.evaluate(eligible('2', () => 0))).toBe(false);
+    expect(canShareScanResult({ status: 'completed', findingsLoaded: true, findingCount: 1 })).toBe(true);
+  });
+
+  it('falls back to stable in-memory decisions when localStorage throws', () => {
+    const unavailable = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+    };
+    const store = createSharePromptStore(unavailable);
+    expect(store.evaluate(eligible('1'))).toBe(true);
+    expect(store.evaluate(eligible('2', () => 0.1))).toBe(true);
+    expect(store.evaluate(eligible('2', () => 0.1))).toBe(false);
+  });
+});
+
+describe('channel sharing', () => {
+  it('uses native file sharing for non-X channels when supported', async () => {
+    const share = vi.fn(async () => {});
+    const file = { name: 'finding.png' };
+    const artifact = buildShareArtifact({ channel: 'elsewhere' });
+
+    await expect(
+      shareWithChannel({
+        artifact,
+        file,
+        navigatorObject: { canShare: () => true, share },
+        downloadFile: vi.fn(),
+        openWindow: vi.fn(),
+      })
+    ).resolves.toEqual({ kind: 'file-shared' });
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining(GITHUB_DESTINATION), files: [file] })
+    );
+  });
+
+  it('always downloads the image and opens a tagged X composer', async () => {
+    const downloadFile = vi.fn();
+    const openWindow = vi.fn();
+    const share = vi.fn();
+    const artifact = buildShareArtifact({ channel: 'x' });
+    const blob = { type: 'image/png' };
+
+    await expect(
+      shareWithChannel({
+        artifact,
+        file: { name: 'finding.png' },
+        blob,
+        navigatorObject: { canShare: () => true, share },
+        downloadFile,
+        openWindow,
+      })
+    ).resolves.toEqual({ kind: 'x-fallback' });
+    expect(share).not.toHaveBeenCalled();
+    expect(downloadFile).toHaveBeenCalledWith(blob, 'open-kritt-security-finding.png');
+    expect(decodeURIComponent(openWindow.mock.calls[0][0])).toContain(X_HANDLE);
+    expect(decodeURIComponent(openWindow.mock.calls[0][0])).toContain(X_DESTINATION);
+    expect(openWindow.mock.calls[0][0]).toBe(xIntentUrl(artifact.caption));
+  });
+
+  it('falls back from image sharing to a GitHub-linked native text share elsewhere', async () => {
+    const share = vi.fn(async () => {});
+    const artifact = buildShareArtifact({ channel: 'elsewhere' });
+
+    await expect(
+      shareWithChannel({
+        artifact,
+        file: { name: 'finding.png' },
+        navigatorObject: { canShare: () => false, share },
+      })
+    ).resolves.toEqual({ kind: 'text-shared' });
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining(GITHUB_DESTINATION) }));
+    expect(share.mock.calls[0][0]).not.toHaveProperty('files');
+  });
+
+  it('reports unsupported sharing and can copy the GitHub post independently', async () => {
+    const artifact = buildShareArtifact({ channel: 'elsewhere' });
+    await expect(shareWithChannel({ artifact, navigatorObject: {} })).resolves.toEqual({ kind: 'unsupported' });
+
+    const writeText = vi.fn(async () => {});
+    await copyShareText(artifact.caption, { navigatorObject: { clipboard: { writeText } } });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining(GITHUB_DESTINATION));
+  });
+});

--- a/frontend/src/pages/ScanDetail.jsx
+++ b/frontend/src/pages/ScanDetail.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { api, ApiError } from '../api/client.js';
 import { useFetch } from '../lib/useFetch.js';
 import { usePageChrome } from '../context/ui.jsx';
@@ -25,6 +25,8 @@ import WorkflowModelConfiguration, {
 import { modelOverridesDraft, modelOverridesEqual, reconcileModelOverrides } from '../lib/modelOverrides.js';
 import { usePagination } from '../lib/usePagination.js';
 import Pagination from '../components/Pagination.jsx';
+import ShareResultDialog from '../components/ShareResultDialog.jsx';
+import { canShareScanResult, highestShareSeverity, sharePromptStore } from '../lib/shareResult.js';
 
 export function scanActions(status) {
   const active = ['prewarming_cache', 'running', 'post_processing'].includes(status);
@@ -59,10 +61,12 @@ export async function loadModelReferences(fetchProviders, fetchCatalog) {
 export default function ScanDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState(null);
   const [extrasOpen, setExtrasOpen] = useState(false);
   const [reviewError, setReviewError] = useState(null);
+  const [shareDialog, setShareDialog] = useState(null);
   const reviewMutations = useRef(createLatestFieldMutationQueue());
   const { data: scan, loading, error, reload } = useFetch(() => api.scan(id), [id], { pollMs: 1000 });
   const {
@@ -99,7 +103,37 @@ export default function ScanDetail() {
     return () => queue.dispose();
   }, [id]);
 
+  useEffect(() => setShareDialog(null), [id]);
+
+  const shareFindingsLoaded = scan?.id === id && Array.isArray(vulns) && !vulnsLoading && !vulnsError;
+  const shareEligible = canShareScanResult({
+    status: scan?.status,
+    findingsLoaded: shareFindingsLoaded,
+    findingCount: vulns?.length || 0,
+  });
+  const shareRequested = searchParams.get('share') === 'result';
+
+  useEffect(() => {
+    if (!shareEligible) return;
+    if (shareRequested) {
+      setShareDialog({ automatic: false });
+      return;
+    }
+    const shouldPrompt = sharePromptStore.evaluate({
+      scanId: id,
+      status: scan.status,
+      findingsLoaded: shareFindingsLoaded,
+      findingCount: vulns.length,
+    });
+    if (shouldPrompt) setShareDialog({ automatic: true });
+  }, [id, scan?.status, shareEligible, shareFindingsLoaded, shareRequested, vulns?.length]);
+
   const findingPages = usePagination(vulns || [], { pageSize: 20, resetKey: id });
+
+  const closeShareDialog = ({ disableAutomaticPrompts = false } = {}) => {
+    if (disableAutomaticPrompts) sharePromptStore.disableAutomaticPrompts();
+    setShareDialog(null);
+  };
 
   const setStatus = async (status) => {
     setBusy(true);
@@ -192,6 +226,7 @@ export default function ScanDetail() {
   if (!scan) return null;
 
   const list = vulns || [];
+  const shareSeverity = highestShareSeverity(list.map(findingSeverity));
   const extraEntries = scan.extra && typeof scan.extra === 'object' ? Object.entries(scan.extra) : [];
   const actions = scanActions(scan.status);
   const agentSkills =
@@ -217,6 +252,9 @@ export default function ScanDetail() {
         overflow: 'hidden',
       }}
     >
+      {shareDialog && scan.id === id && (
+        <ShareResultDialog severity={shareSeverity} automatic={shareDialog.automatic} onClose={closeShareDialog} />
+      )}
       <div
         style={{
           height: '100%',
@@ -226,10 +264,12 @@ export default function ScanDetail() {
         }}
       >
         <div
+          className="scan-detail-heading"
           style={{
             display: 'flex',
             alignItems: 'flex-start',
             justifyContent: 'space-between',
+            gap: 16,
           }}
         >
           <div>
@@ -261,7 +301,17 @@ export default function ScanDetail() {
               · {scan.repoKind === 'local' ? 'local snapshot' : `@${scan.commitShort}`}
             </div>
           </div>
-          <div style={{ display: 'flex', gap: 8 }}>
+          <div className="scan-detail-actions" style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {shareEligible && (
+              <Button
+                variant="subtle"
+                style={{ height: 32 }}
+                onClick={() => setShareDialog({ automatic: false })}
+                title="Create a sanitized image without repository or vulnerability details"
+              >
+                Share result
+              </Button>
+            )}
             <Button
               variant="ghost"
               style={{ height: 32 }}


### PR DESCRIPTION
## What changed

- add a persistent privacy-safe **Share result** action for completed scans with findings
- generate a branded 1200×630 open·kritt PNG locally with an optional normalized-severity disclosure
- add X-specific sharing with `@Kritt_AI` and `https://kritt.ai/`, plus GitHub attribution for all other channels
- add stable, browser-local automatic prompt decisions with a global opt-out
- add a persistent **Give back to the community by sharing** sidebar CTA and scan-free community card
- add a direct `?share=result` link for manually opening the scan share dialog

## Why

This creates a privacy-preserving viral loop that lets researchers promote open·kritt without exposing repository names, findings, paths, code, reports, PoCs, scan IDs, or other classified scan data.

The X action opens a prefilled composer and downloads the PNG for manual attachment because the Web Share API cannot reliably target X.

## Validation

- `npm test` — 34 files, 236 tests passed
- `npm run lint`
- scoped Prettier check for all changed files
- `npm run build`
- desktop visual QA in light and dark themes
