### PR TITLE
feat(frontend): add community star support

### DIFF
--- a/frontend/src/components/ShareResultDialog.jsx
+++ b/frontend/src/components/ShareResultDialog.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from './ui.jsx';
 import { useModalDialog } from '../lib/useModalDialog.js';
 import {
+  GITHUB_DESTINATION,
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_IMAGE_FILENAME,
@@ -151,11 +152,11 @@ export default function ShareResultDialog({ severity = null, mode = 'result', on
         <div className="share-result-header">
           <div>
             <div id="share-result-title" className="share-result-title">
-              It’s open source. Give back to the community.
+              {communityMode ? 'Support the open-source community.' : 'It’s open source. Give back to the community.'}
             </div>
             <div className="share-result-subtitle">
               {communityMode
-                ? 'Help more security researchers discover, use, and improve open·kritt.'
+                ? 'Share open·kritt with other researchers or star it on GitHub. Both help more people discover, use, and improve the project.'
                 : 'Share what open·kritt helped you accomplish - never the classified vulnerability details.'}
             </div>
           </div>
@@ -165,6 +166,17 @@ export default function ShareResultDialog({ severity = null, mode = 'result', on
         </div>
 
         <div className="share-result-body">
+          {communityMode && (
+            <div className="share-result-star-support">
+              <span>
+                <strong>Prefer not to post?</strong> A GitHub star is a quick way to help open·kritt grow.
+              </span>
+              <a href={GITHUB_DESTINATION} target="_blank" rel="noreferrer">
+                Star on GitHub ↗
+              </a>
+            </div>
+          )}
+
           <canvas
             ref={canvasRef}
             className="share-result-preview"

--- a/frontend/src/components/ShareResultDialog.test.jsx
+++ b/frontend/src/components/ShareResultDialog.test.jsx
@@ -15,14 +15,22 @@ describe('ShareResultDialog', () => {
     expect(html).toContain('Share elsewhere');
     expect(html).not.toContain('Don’t show this automatically again');
     expect(html).toContain('No repository, finding title, path, code, report, PoC');
+    expect(html).not.toContain('Star on GitHub');
   });
 
   it('renders a project-focused community sharing prompt without scan controls', () => {
     const html = renderToStaticMarkup(<ShareResultDialog mode="community" onClose={() => {}} />);
 
-    expect(html).toContain('It’s open source. Give back to the community.');
+    expect(html).toContain('Support the open-source community.');
+    expect(html).toContain('Share open·kritt with other researchers or star it on GitHub.');
     expect(html).toContain('Open-source security is stronger when we build together.');
     expect(html).toContain('No scan or vulnerability data is included.');
+    expect(html).toContain('Prefer not to post?');
+    expect(html).toContain('A GitHub star is a quick way to help open·kritt grow.');
+    expect(html).toContain('href="https://github.com/Kritt-ai/open-kritt"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noreferrer"');
+    expect(html.indexOf('Prefer not to post?')).toBeLessThan(html.indexOf('Share-card preview'));
     expect(html).not.toContain('Include severity');
     expect(html).not.toContain('Don’t show this automatically again');
   });

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -69,7 +69,7 @@ export function CommunityLinks() {
 export function CommunityShareButton({ onClick }) {
   return (
     <button type="button" className="sidebar-community-share" onClick={onClick}>
-      Share open·kritt
+      Support open·kritt
     </button>
   );
 }

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -19,7 +19,7 @@ describe('sidebar community links', () => {
   it('renders the persistent community sharing call to action', () => {
     const html = renderToStaticMarkup(<CommunityShareButton onClick={() => {}} />);
 
-    expect(html).toContain('Share open·kritt');
+    expect(html).toContain('Support open·kritt');
     expect(html).toContain('type="button"');
     expect(html).not.toContain('↗');
   });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1360,6 +1360,42 @@ a {
   gap: 8px;
 }
 
+.share-result-star-support {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.share-result-star-support strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.share-result-star-support a {
+  flex: none;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.share-result-star-support a:hover,
+.share-result-star-support a:focus-visible {
+  color: var(--accent);
+}
+
+.share-result-star-support a:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
 @media (max-width: 700px) {
   .scan-detail-heading {
     flex-direction: column;
@@ -1407,6 +1443,12 @@ a {
     min-width: 0;
     padding-right: 10px;
     padding-left: 10px;
+  }
+
+  .share-result-star-support {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
   }
 
   .finding-share-banner {


### PR DESCRIPTION
## What changed

- rename the quiet sidebar CTA from **Share open·kritt** to **Support open·kritt**
- broaden the community popup copy to present sharing and GitHub stars as two ways to help
- add a restrained, keyboard-accessible **Star on GitHub** callout above the share-card preview
- keep the star prompt out of scan-result sharing
- stack the new callout cleanly on mobile

## Why

Not every user wants to publish a post. Offering a GitHub star gives users a lower-friction way to support the project while keeping the existing sharing flow available.

The sidebar CTA retains its current subtle visual weight so the community prompt does not become distracting.

## Validation

- `npm test` — 34 files, 235 tests passed
- `npm run lint`
- scoped Prettier check for all changed files
- `npm run build`
