### PR TITLE
fix(frontend): render real required vulnerability key count on terminal step

### DIFF
--- a/frontend/src/pages/WorkflowDetail.jsx
+++ b/frontend/src/pages/WorkflowDetail.jsx
@@ -7,7 +7,7 @@ import { Spinner, ErrorState, Button } from '../components/ui.jsx';
 import { PromptHighlight } from '../components/PromptEditor.jsx';
 import Drawer from '../components/Drawer.jsx';
 import { availableKeysForDepth, groupByDepth, workflowDeleteState } from '../lib/workflow.js';
-import { parseTemplateRefs, refResolves } from '../lib/keys.js';
+import { parseTemplateRefs, refResolves, REQUIRED_VULN_KEYS } from '../lib/keys.js';
 import { downloadWorkflowExport } from '../lib/workflowTransfer.js';
 
 export default function WorkflowDetail() {
@@ -328,7 +328,7 @@ function Connector({ level, next }) {
   );
 }
 
-function StepPanel({ step, steps, editTo, onClose }) {
+export function StepPanel({ step, steps, editTo, onClose }) {
   const available = availableKeysForDepth(steps, step.depth);
   const parsedRefs = parseTemplateRefs(step.content);
   const refs = [...new Set(parsedRefs.refs)];
@@ -526,7 +526,8 @@ function StepPanel({ step, steps, editTo, onClose }) {
               lineHeight: 1.5,
             }}
           >
-            ✓ Terminal step — emits all 9 required vulnerability keys to workflows.vulnerabilities.
+            ✓ Terminal step — emits all {REQUIRED_VULN_KEYS.length} required vulnerability keys to
+            workflows.vulnerabilities.
           </div>
         )}
 

--- a/frontend/src/pages/WorkflowDetail.test.jsx
+++ b/frontend/src/pages/WorkflowDetail.test.jsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { StepPanel } from './WorkflowDetail.jsx';
+import { REQUIRED_VULN_KEYS } from '../lib/keys.js';
+
+// A minimal terminal step: isLast triggers the "emits all N required vulnerability
+// keys" summary. depth 0 with an empty steps array keeps availableKeysForDepth happy.
+const terminalStep = {
+  depth: 0,
+  name: 'Report',
+  content: '',
+  multiOutput: false,
+  consumesAll: false,
+  outputTable: 'workflows.vulnerabilities',
+  outputFormat: {},
+  isLast: true,
+};
+
+describe('WorkflowDetail terminal step summary', () => {
+  it('reports the real number of required vulnerability keys, not a hardcoded value', () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <StepPanel step={terminalStep} steps={[terminalStep]} editTo="/workflows/1/steps/1" onClose={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain(`emits all ${REQUIRED_VULN_KEYS.length} required vulnerability keys`);
+    // Guard against the regression this test covers: the count was hardcoded to 9
+    // while REQUIRED_VULN_KEYS actually has 8 entries.
+    expect(html).not.toContain('emits all 9 required vulnerability keys');
+  });
+});


### PR DESCRIPTION
## What & why

The WorkflowDetail terminal-step summary hardcoded the number of required
vulnerability keys as **9**, but `REQUIRED_VULN_KEYS` (`frontend/src/lib/keys.js`)
actually has **8** entries. WorkflowBuilder already renders this count dynamically
(`✓ All {REQUIRED_VULN_KEYS.length} required vulnerability keys...`), so the two
views disagreed (9 vs 8).

This derives the number from `REQUIRED_VULN_KEYS.length` in WorkflowDetail too, so
both places render the real value and stay in sync if the key list ever changes.

Closes #57

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] frontend

## Checklist

- [x] Commits use Conventional Commits (no empty `()` scope)
- [x] Lint & format pass (`npm run lint` / `npm run format:check` on changed files)
- [x] Tests added/updated and passing
- [x] Docs updated if behavior or config changed (n/a)
- [x] No secrets committed

## Test verification (RED → GREEN)

Added `frontend/src/pages/WorkflowDetail.test.jsx`, which renders `StepPanel` for a
terminal step and asserts the summary reports `REQUIRED_VULN_KEYS.length` keys.
(`StepPanel` is exported for the test, matching the existing precedent in
`Accounts.jsx`, which exports subcomponents for the same reason.)

RED — on the unmodified code (hardcoded `9`):

```
FAIL  src/pages/WorkflowDetail.test.jsx > reports the real number of required vulnerability keys, not a hardcoded value
Expected: "emits all 8 required vulnerability keys"
Received: "...✓ Terminal step — emits all 9 required vulnerability keys to workflows.vulnerabilities..."
 Tests  1 failed (1)
```

GREEN — with the fix:

```
 Test Files  35 passed (35)
      Tests  236 passed (236)
```

## Notes for reviewers

One-line behavioral fix plus a focused regression test. No API or data changes.