### PR TITLE
fix(cli): fall back to a visible secret prompt when raw mode is unavailable

### DIFF
--- a/scripts/kritt-lib.mjs
+++ b/scripts/kritt-lib.mjs
@@ -696,8 +696,13 @@ async function askLine(question, io) {
 }
 
 async function askSecret(question, io) {
+  // Some interactive terminals — notably Git Bash / MSYS on Windows — expose a
+  // stdin whose isTTY is undefined and cannot enter raw mode. Rather than crashing
+  // setup (issue #55), fall back to a visible line prompt so the value can still be
+  // entered, warning the user first that the input will not be hidden.
   if (!io.input.isTTY || typeof io.input.setRawMode !== 'function') {
-    throw new Error('Secret entry requires an interactive terminal.');
+    write(io, 'Warning: this terminal cannot hide input; the value will be visible as you type.');
+    return askLine(question, io);
   }
 
   io.output.write(question);
@@ -734,7 +739,7 @@ async function askSecret(question, io) {
   });
 }
 
-function createPrompter(io) {
+export function createPrompter(io) {
   return {
     ask: (question) => askLine(question, io),
     secret: (question) => askSecret(question, io),

--- a/scripts/kritt-lib.mjs
+++ b/scripts/kritt-lib.mjs
@@ -698,11 +698,14 @@ async function askLine(question, io) {
 async function askSecret(question, io) {
   // Some interactive terminals — notably Git Bash / MSYS on Windows — expose a
   // stdin whose isTTY is undefined and cannot enter raw mode. Rather than crashing
-  // setup (issue #55), fall back to a visible line prompt so the value can still be
-  // entered, warning the user first that the input will not be hidden.
+  // setup (issue #55), offer a visible line prompt as an explicit opt-in fallback.
   if (!io.input.isTTY || typeof io.input.setRawMode !== 'function') {
     write(io, 'Warning: this terminal cannot hide input; the value will be visible as you type.');
-    return askLine(question, io);
+    const consent = await askLine('Continue with visible input? [y/N] ', io);
+    if (!/^(y|yes)$/i.test(consent)) return '';
+
+    const visibleQuestion = question.replace(/input is hidden/i, 'input will be visible');
+    return askLine(visibleQuestion, io);
   }
 
   io.output.write(question);

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -3,9 +3,11 @@ import { EventEmitter } from 'node:events';
 import { chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import test from 'node:test';
 
 import {
+  createPrompter,
   ensureEnvFile,
   getSetupStatus,
   importCodexAuth,
@@ -642,4 +644,21 @@ test('help is available for subcommands and unknown commands fail clearly', asyn
   const unknownIo = testIo();
   assert.equal(await runCli(['unknown'], { ...project, io: unknownIo }), 1);
   assert.match(unknownIo.error.text, /Unknown command/);
+});
+
+test('secret prompt falls back to a visible prompt when the terminal cannot enter raw mode (issue #55)', async () => {
+  const apiKey = 'sk-or-visible-fallback';
+  // Reproduces Windows Git Bash / MSYS: an interactive stdin whose isTTY is
+  // undefined and that has no setRawMode. Before the fix this threw
+  // "Secret entry requires an interactive terminal." and aborted setup.
+  const input = new PassThrough();
+  const output = new BufferStream();
+  const prompter = createPrompter({ input, output, error: new BufferStream() });
+
+  const pending = prompter.secret('Enter OpenRouter API key (input is hidden): ');
+  input.write(`${apiKey}\n`);
+  input.end();
+
+  assert.equal(await pending, apiKey);
+  assert.match(output.text, /cannot hide input/);
 });

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -646,19 +646,52 @@ test('help is available for subcommands and unknown commands fail clearly', asyn
   assert.match(unknownIo.error.text, /Unknown command/);
 });
 
-test('secret prompt falls back to a visible prompt when the terminal cannot enter raw mode (issue #55)', async () => {
-  const apiKey = 'sk-or-visible-fallback';
-  // Reproduces Windows Git Bash / MSYS: an interactive stdin whose isTTY is
-  // undefined and that has no setRawMode. Before the fix this threw
-  // "Secret entry requires an interactive terminal." and aborted setup.
+test('secret prompt declines visible input by default when raw mode is unavailable', async () => {
   const input = new PassThrough();
   const output = new BufferStream();
   const prompter = createPrompter({ input, output, error: new BufferStream() });
 
   const pending = prompter.secret('Enter OpenRouter API key (input is hidden): ');
-  input.write(`${apiKey}\n`);
-  input.end();
+  input.end('no\n');
+
+  assert.equal(await pending, '');
+  assert.match(output.text, /cannot hide input/);
+  assert.match(output.text, /Continue with visible input\? \[y\/N\]/);
+  assert.doesNotMatch(output.text, /Enter OpenRouter API key/);
+});
+
+test('secret prompt requires consent before falling back to visible input', async () => {
+  const apiKey = 'sk-or-visible-fallback';
+  const input = new PassThrough();
+  const output = new BufferStream();
+  const prompter = createPrompter({ input, output, error: new BufferStream() });
+
+  const pending = prompter.secret('Enter OpenRouter API key (input is hidden): ');
+  input.write('yes\n');
+  await new Promise((resolve) => setImmediate(resolve));
+  input.end(`${apiKey}\n`);
 
   assert.equal(await pending, apiKey);
-  assert.match(output.text, /cannot hide input/);
+  assert.match(output.text, /Enter OpenRouter API key \(input will be visible\):/);
+  assert.doesNotMatch(output.text, /input is hidden/);
+  assert.doesNotMatch(output.text, new RegExp(apiKey));
+});
+
+test('secret prompt keeps using hidden raw-mode input when it is available', async () => {
+  const apiKey = 'sk-or-hidden-input';
+  const input = new EventEmitter();
+  const output = new BufferStream();
+  const rawModes = [];
+  input.isTTY = true;
+  input.resume = () => {};
+  input.setRawMode = (enabled) => rawModes.push(enabled);
+  const prompter = createPrompter({ input, output, error: new BufferStream() });
+
+  const pending = prompter.secret('Enter OpenRouter API key (input is hidden): ');
+  input.emit('data', Buffer.from(`${apiKey}\n`));
+
+  assert.equal(await pending, apiKey);
+  assert.deepEqual(rawModes, [true, false]);
+  assert.doesNotMatch(output.text, /visible as you type/);
+  assert.doesNotMatch(output.text, new RegExp(apiKey));
 });


### PR DESCRIPTION
## What & why

`./kritt setup` crashes on Windows Git Bash / MSYS with:

```
Error: Secret entry requires an interactive terminal.
    at askSecret (scripts/kritt-lib.mjs)
```

`askSecret` requires a raw-capable TTY, but on MSYS `process.stdin.isTTY` is
`undefined` even in a genuinely interactive terminal (a long-standing Node-on-Windows
limitation), so entering an OpenRouter — or any — API key aborts setup and forces
users to hand-edit `.env`.

Instead of throwing, the guard now warns that input will be visible and falls back to
the existing `askLine()` prompt, so setup completes on terminals that cannot enter raw
mode. Raw mode is genuinely unavailable on MSYS, so echoing with an explicit warning is
the honest degradation (the alternative is the current crash). Terminals that *can* hide
input are unaffected — they still use the hidden raw-mode path.

`createPrompter` is exported so the fallback path can be unit-tested.

Closes #55

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] docs / CI / tooling (CLI — `scripts/`)

## Checklist

- [x] Commits use Conventional Commits (no empty `()` scope)
- [x] Lint & format pass (prettier on changed files)
- [x] Tests added/updated and passing
- [x] No secrets committed

## Test verification (RED → GREEN)

Added a test in `scripts/kritt.test.mjs` that builds `createPrompter` over a non-TTY
stdin (a `PassThrough` with no `setRawMode`, `isTTY` undefined — the MSYS shape) and
asserts `.secret()` resolves the entered value instead of throwing.

RED — on the unmodified code (`askSecret` throws):

```
not ok 38 - secret prompt falls back to a visible prompt when the terminal cannot enter raw mode (issue #55)
  error: 'Secret entry requires an interactive terminal.'
# tests 38
# pass 37
# fail 1
```

GREEN — with the fix:

```
# tests 38
# pass 38
# fail 0
```

## Notes for reviewers

- The tradeoff: on a terminal that cannot hide input, the key is echoed. This is
  unavoidable there, and the warning is printed before the prompt. Hiding input on
  Git Bash would need `winpty`/native-helper complexity that isn't worth it for this
  path.
- Minor follow-up (left out to keep this focused): the caller's prompt still reads
  "(input is hidden)"; on the fallback path the preceding warning overrides that.