### PR TITLE
fix(engine): prune only dangling images so tagged scan runners survive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,8 @@ ENGINE_DATA_DIR_HOST=./.data/engine
 ENGINE_MIN_FREE_STORAGE_GB=20
 # Disable the free-storage launch safeguard. This can allow the host disk to fill.
 ENGINE_IGNORE_LOW_STORAGE=false
-# After task completion, remove unused build cache and images, plus stopped scan containers.
-# Images referenced by any container, service containers, bind mounts, database data, credentials, and volumes are preserved.
+# After task completion, remove unused build cache and dangling (untagged) images, plus stopped scan containers.
+# Tagged images (including custom scan runners), images referenced by any container, service containers, bind mounts, database data, credentials, and volumes are preserved.
 ENGINE_AUTO_PRUNE_DOCKER_BUILD_CACHE=true
 ENGINE_AUTO_PRUNE_UNUSED_DOCKER_IMAGES=true
 ENGINE_DOCKER_BUILD_CACHE_KEEP_GB=0

--- a/engine/open_kritt_engine/storage_cleanup.py
+++ b/engine/open_kritt_engine/storage_cleanup.py
@@ -4,6 +4,11 @@ import subprocess
 
 SCAN_RUNNER_LABEL = "open-kritt.scan-runner=1"
 
+# Reclaim only dangling (untagged) images. Adding --all would also collect tagged
+# images that happen to be unreferenced at prune time, which deletes a custom scan
+# runner image between jobs (issue #43); tagged images are kept instead.
+IMAGE_PRUNE_ARGS = ("image", "prune", "--force")
+
 
 def _docker_binary() -> str | None:
     return shutil.which(os.getenv("ENGINE_DOCKER_BIN", "docker"))
@@ -54,13 +59,13 @@ def prune_docker_build_cache(*, keep_storage_bytes: int, timeout_seconds: float 
 
 
 def prune_unused_docker_images(*, timeout_seconds: float = 300.0) -> str | None:
-    """Remove images unused by every running and stopped container."""
+    """Remove dangling (untagged) images, keeping tagged images such as scan runners."""
 
     docker = _docker_binary()
     if not docker:
         return None
     return _run_docker_cleanup(
-        [docker, "image", "prune", "--all", "--force"],
+        [docker, *IMAGE_PRUNE_ARGS],
         timeout_seconds=timeout_seconds,
     )
 

--- a/engine/tests/test_storage_cleanup.py
+++ b/engine/tests/test_storage_cleanup.py
@@ -34,18 +34,21 @@ def test_docker_builder_prune_is_optional_when_docker_is_unavailable(monkeypatch
     assert storage_cleanup.prune_docker_build_cache(keep_storage_bytes=0) is None
 
 
-def test_unused_image_prune_removes_tagged_and_untagged_images(monkeypatch):
+def test_unused_image_prune_keeps_tagged_images(monkeypatch):
+    """Auto-prune must not pass --all, so a tagged scan runner image survives (issue #43)."""
     calls = []
 
     def run(command, **kwargs):
         calls.append((command, kwargs))
-        return SimpleNamespace(returncode=0, stdout="Total reclaimed space: 3GB\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="Total reclaimed space: 1GB\n", stderr="")
 
     monkeypatch.setattr(storage_cleanup.shutil, "which", lambda _binary: "/usr/bin/docker")
     monkeypatch.setattr(storage_cleanup.subprocess, "run", run)
 
-    assert storage_cleanup.prune_unused_docker_images() == "Total reclaimed space: 3GB"
-    assert calls[0][0] == ["/usr/bin/docker", "image", "prune", "--all", "--force"]
+    assert storage_cleanup.prune_unused_docker_images() == "Total reclaimed space: 1GB"
+
+    assert "--all" not in calls[0][0]
+    assert calls[0][0] == ["/usr/bin/docker", "image", "prune", "--force"]
 
 
 def test_stopped_container_prune_is_scoped_to_scan_runner_label(monkeypatch):


### PR DESCRIPTION
## What & why

Related: #43

`ENGINE_AUTO_PRUNE_UNUSED_DOCKER_IMAGES` (default-on) makes the engine run
`docker image prune --all --force`. Because stopped scan-runner containers are
pruned **immediately beforehand** (`prune_stopped_scan_containers()` then
`prune_unused_docker_images()` in `worker.py`), a custom **tagged** scan-runner
image is unreferenced at that exact moment, and `--all` then deletes it
deterministically. The next scan either fails startup validation
(`Scan runner image is not available`) or silently runs without the toolchain.

This drops `--all`, so the prune runs `docker image prune --force` and reclaims
only **dangling (untagged)** images. Tagged images — including a custom scan
runner — survive auto-prune. Build-cache pruning
(`ENGINE_AUTO_PRUNE_DOCKER_BUILD_CACHE`) is untouched; it still reclaims builder
layers via its own `docker builder prune --all`.

### Design tradeoff — this is option 2 of the 3 the reporter proposed

In #43 the reporter listed three fixes and asked which you'd prefer. This PR
implements **option 2 (the smallest diff)**:

1. **Exclude the configured runner image** via a build-time label + `--filter "label!=..."` (or re-pull after prune).
2. **Narrow the prune** — drop `--all` so only dangling images are removed. ← **this PR**
3. **Default the flag to false** when `ENGINE_SCAN_RUNNER_IMAGE` differs from the engine's own image.

The tradeoff of option 2: the auto-prune no longer reclaims *tagged-but-unreferenced*
images at all — only dangling ones (which is the usual intent of an image prune).
That is a deliberate narrowing of scope, not a bug. If you'd rather keep collecting
tagged images and instead **protect only the runner** (option 1, label filter) or
**flip the default conditionally** (option 3), I'm happy to switch this PR to that
approach — just say which you prefer. I did not mark this as `Closes #43` because the
choice between the three options is yours.

## Test verification (RED → GREEN)

The command literal is now a named constant `IMAGE_PRUNE_ARGS = ("image", "prune", "--force")`.
`engine/tests/test_storage_cleanup.py` asserts the auto-prune argv contains **no `--all`**.
The old `test_unused_image_prune_removes_tagged_and_untagged_images` asserted the
buggy `--all` behavior and was replaced (a contradictory assertion could not remain).

**RED** — new test on the *unmodified* base (production code still had `--all`):

```
    def test_unused_image_prune_keeps_tagged_images(monkeypatch):
        ...
        storage_cleanup.prune_unused_docker_images()
>       assert "--all" not in calls[0][0]
E       AssertionError: assert '--all' not in ['/usr/bin/docker', 'image', 'prune', '--all', '--force']
FAILED tests/test_storage_cleanup.py::test_unused_image_prune_keeps_tagged_images
============================== 1 failed in 0.02s ===============================
```

**GREEN** — after dropping `--all`:

```
tests/test_storage_cleanup.py ....                                       [100%]
============================== 4 passed in 0.01s ===============================
```

Full engine suite unchanged vs base — **289 passed** in both (the 5 pre-existing
`test_engine.py` worker rate-limit failures are unrelated to this change and fail
identically on the unmodified base branch here, running under Python 3.14):

```
base:  5 failed, 289 passed
patch: 5 failed, 289 passed
```

`ruff check` / `ruff format --check` clean on the changed files;
`node scripts/sync-version.mjs --check` passes (VERSION untouched).

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] engine
- [x] docs / CI / tooling  (`.env.example` comment updated to match the new prune scope)

## Checklist

- [x] Commits use Conventional Commits (no empty `()` scope)
- [x] Lint & format pass (`ruff check .`)
- [x] Tests added/updated and passing where it makes sense
- [x] Docs updated if behavior or config changed (`.env.example`)
- [x] No secrets committed

## Notes for reviewers

- Focus point: this is a **behavior/default change** (prune scope narrows from
  all-unused to dangling-only). It is intentional and scoped to the one function;
  build-cache prune and container prune are unchanged.
- Happy to pivot to option 1 or option 3 from #43 if you prefer that direction.

---

_Assistance disclosure: implemented with AI assistance (Claude Code); the fix,
tests, and RED→GREEN verification were reviewed by the author._
