### PR TITLE
fix(engine): validate Codex CLI installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - run: npm test
 
   engine:
-    name: engine (lint)
+    name: engine (lint • image)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -114,6 +114,8 @@ jobs:
         continue-on-error: true
       - run: ruff format --check .
         continue-on-error: true
+      - name: Build the engine image
+        run: docker build --tag open-kritt-engine-ci .
       # TODO: re-enable the test suite. Several tests currently assume a writable
       # /root home (codex/claude dirs) and one has an outdated assertion, so they
       # fail on CI runners. Lint-only for now.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 RUN npm install --global --no-audit --no-fund @openai/codex@0.145.0 \
+    && codex --version \
     && npm install --global --no-audit --no-fund --allow-scripts=@anthropic-ai/claude-code @anthropic-ai/claude-code@2.1.215
 COPY . .
 RUN npx prisma generate

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends bash ca-certificates curl git util-linux \
     && npm install --global --no-audit --no-fund npm@12.0.1 \
     && npm install --global --no-audit --no-fund @openai/codex@0.145.0 \
+    && codex --version \
     && npm install --global --no-audit --no-fund --allow-scripts=@anthropic-ai/claude-code @anthropic-ai/claude-code@2.1.215 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/engine/open_kritt_engine/codex_updater.py
+++ b/engine/open_kritt_engine/codex_updater.py
@@ -105,13 +105,15 @@ class CodexUpdater:
                 return CodexUpdateResult(True, False, False, before_version, None)
 
             after_version = self._version()
+            if not after_version:
+                LOGGER.warning("Codex CLI update completed but the installed CLI could not start")
+                return CodexUpdateResult(True, False, False, before_version, None)
+
             updated = before_version != after_version
-            if updated and after_version:
+            if updated:
                 LOGGER.info("updated Codex CLI from %s to %s", before_version or "unknown", after_version)
-            elif after_version:
-                LOGGER.info("Codex CLI is already up to date (%s)", after_version)
             else:
-                LOGGER.warning("Codex CLI update completed but its installed version could not be read")
+                LOGGER.info("Codex CLI is already up to date (%s)", after_version)
             return CodexUpdateResult(True, True, updated, before_version, after_version)
         finally:
             self.gate.end_update()

--- a/engine/tests/test_codex_updater.py
+++ b/engine/tests/test_codex_updater.py
@@ -50,6 +50,31 @@ def test_codex_updater_keeps_existing_cli_when_npm_fails():
     ]
 
 
+def test_codex_updater_rejects_install_when_installed_cli_cannot_start():
+    calls = []
+    version_checks = iter(
+        [
+            _completed(["codex", "--version"], stdout="codex-cli 0.142.2\n"),
+            _completed(["codex", "--version"], returncode=1),
+        ]
+    )
+
+    def run_command(command, **kwargs):
+        calls.append(command)
+        if command[0] == "codex":
+            return next(version_checks)
+        return _completed(command)
+
+    result = CodexUpdater(run_command=run_command).update()
+
+    assert result == CodexUpdateResult(True, False, False, "0.142.2", None)
+    assert calls == [
+        ["codex", "--version"],
+        ["npm", "install", "--global", "--no-audit", "--no-fund", "@openai/codex@latest"],
+        ["codex", "--version"],
+    ]
+
+
 def test_codex_updater_treats_timeout_as_non_fatal():
     def run_command(command, **kwargs):
         if command[0] == "codex":

--- a/engine/tests/test_security_hardening.py
+++ b/engine/tests/test_security_hardening.py
@@ -289,6 +289,7 @@ def test_agent_cli_builds_use_exact_package_versions():
     assert "npm@12.0.1" in dockerfiles["engine"]
     for name in ("engine", "backend"):
         assert "@openai/codex@0.145.0" in dockerfiles[name]
+        assert "@openai/codex@0.145.0 \\\n    && codex --version" in dockerfiles[name]
         assert "@anthropic-ai/claude-code@2.1.215" in dockerfiles[name]
     assert "@anthropic-ai/claude-code@2.1.215" in dockerfiles["claude-runner"]
 


### PR DESCRIPTION
## What changed

- smoke-test the bundled Codex CLI during engine and backend image builds
- reject runtime Codex updates when the installed CLI cannot start
- add regression coverage for missing platform executables
- build the engine image in CI

## Why

npm treats Codex's platform executable as an optional dependency. A failed optional dependency download can therefore leave only the JavaScript launcher installed while npm and Docker still report success. The resulting image fails before authentication with a missing `@openai/codex-linux-*` package.

This change makes image creation fail immediately instead of caching or shipping an unusable Codex installation.

## Validation

- `ruff check` and `ruff format --check` on the touched engine files
- complete engine pytest suite
- backend Prisma validation, lint, format check, and all 159 tests
- Linux x64 engine image build (`codex-cli 0.145.0`)
- backend image build and container smoke check (`codex-cli 0.145.0`)
- workflow YAML parse and `git diff --check`

The repository-wide Ruff check still reports the pre-existing import-order issue in `engine/open_kritt_engine/model_output_artifacts.py`; no unrelated file was changed.
