### PR TITLE
fix(frontend): allow concurrent account quota starts

### DIFF
--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -27,8 +27,8 @@ export default function Accounts() {
   const [error, setError] = useState(null);
   const [editing, setEditing] = useState(null);
   const [removingAccount, setRemovingAccount] = useState(null);
-  const [startingUsage, setStartingUsage] = useState(null);
-  const [resettingUsage, setResettingUsage] = useState(null);
+  const [startingUsage, setStartingUsage] = useState(() => new Set());
+  const [resettingUsage, setResettingUsage] = useState(() => new Set());
   const [loadingProviders, setLoadingProviders] = useState(() => new Set());
   const [providerErrors, setProviderErrors] = useState({});
   const loadSequence = useRef(0);
@@ -137,13 +137,13 @@ export default function Accounts() {
 
   const startWeeklyUsage = async (account) => {
     setError(null);
-    setStartingUsage(account.id);
+    setStartingUsage((current) => updatePendingAccounts(current, account.id, true));
     try {
       await startCodexWeeklyUsageUntilStarted(account.id, api.startCodexWeeklyUsage, setData);
     } catch (nextError) {
       setError(nextError);
     } finally {
-      setStartingUsage(null);
+      setStartingUsage((current) => updatePendingAccounts(current, account.id, false));
     }
   };
 
@@ -152,13 +152,13 @@ export default function Accounts() {
     const label = account.email || account.label;
     if (!window.confirm(`Use 1 of ${available} manual resets for ${label}?\n\nThis cannot be undone.`)) return;
     setError(null);
-    setResettingUsage(account.id);
+    setResettingUsage((current) => updatePendingAccounts(current, account.id, true));
     try {
       setData(await api.useCodexManualReset(account.id));
     } catch (nextError) {
       setError(nextError);
     } finally {
-      setResettingUsage(null);
+      setResettingUsage((current) => updatePendingAccounts(current, account.id, false));
     }
   };
 
@@ -310,8 +310,8 @@ function ProviderCard({
               onStartWeeklyUsage={() => onStartWeeklyUsage(account)}
               onUseManualReset={() => onUseManualReset(account)}
               removing={removingAccount === `${provider.id}:${account.id}`}
-              startingUsage={startingUsage === account.id}
-              resettingUsage={resettingUsage === account.id}
+              startingUsage={startingUsage.has(account.id)}
+              resettingUsage={resettingUsage.has(account.id)}
             />
           ))
         ) : (
@@ -356,6 +356,13 @@ export function providerActionLabel(provider) {
   if (provider.id === 'codex') return signInRequired ? 'Sign in to Codex again' : 'Add Codex account';
   if (signInRequired) return 'Sign in to Claude again';
   return 'Add Claude account';
+}
+
+export function updatePendingAccounts(current, accountId, pending) {
+  const next = new Set(current);
+  if (pending) next.add(accountId);
+  else next.delete(accountId);
+  return next;
 }
 
 export function providerReloginAccountId(provider) {

--- a/frontend/src/pages/Accounts.test.js
+++ b/frontend/src/pages/Accounts.test.js
@@ -17,6 +17,7 @@ import {
   removeProviderFromOverview,
   replaceAccountProvider,
   startCodexWeeklyUsageUntilStarted,
+  updatePendingAccounts,
 } from './Accounts.jsx';
 
 describe('expired Codex login', () => {
@@ -262,6 +263,17 @@ describe('Codex weekly usage', () => {
     expect(html).toContain('account-weekly-spinner');
     expect(html).toContain('Manual resets');
     expect(html).toContain('3 available');
+  });
+
+  it('tracks concurrent quota starts independently', () => {
+    let pending = updatePendingAccounts(new Set(), 'reviewer', true);
+    pending = updatePendingAccounts(pending, 'researcher', true);
+
+    expect([...pending]).toEqual(['reviewer', 'researcher']);
+
+    pending = updatePendingAccounts(pending, 'reviewer', false);
+
+    expect([...pending]).toEqual(['researcher']);
   });
 
   it('shows but disables reset use when no usage window is eligible', () => {


### PR DESCRIPTION
## What & why

Track Codex quota-start and manual-reset progress independently per account in the Accounts tab.

Previously, the page stored one active account ID. Starting quota for a second account replaced the first account's busy state, and completion of either request cleared the other account's indicator. A set of pending account IDs now keeps concurrent requests independent.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `chore` / `test` / `ci`
- [ ] Breaking change (`!` / `BREAKING CHANGE:`)

## Affected components

- [x] frontend
- [ ] backend
- [ ] engine
- [ ] database (migration)
- [ ] docs / CI / tooling

## Checklist

By submitting this pull request, you agree to the
[Contribution Terms](https://github.com/Kritt-ai/open-kritt/blob/main/CONTRIBUTION_TERMS.md),
including assignment of your rights in the contribution. No separate signature, form,
or checkbox is required.

- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (no empty `()` scope)
- [x] ESLint passes and the changed files pass Prettier
- [x] Tests added/updated and passing where it makes sense
- [x] Docs are not needed for this behavior-only fix
- [x] No database changes
- [x] No secrets committed

## Validation

- `npm run lint`
- `npm test` — 240 tests passed
- `npm run build`
- `npx prettier --check src/pages/Accounts.jsx src/pages/Accounts.test.js`

The full frontend Prettier check still reports the pre-existing formatting issue in `src/components/Markdown.jsx`, which this PR does not modify.

## Notes for reviewers

The regression test verifies that starting a second account keeps both account IDs pending, and completing the first removes only that account while leaving the second running.
