### PR TITLE
docs: fix contributing code fence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ Thanks for helping improve open·kritt. Please follow our
 You need Git, Docker with Docker Compose, and Node.js 20 or newer. Fork the
 repository, then:
 
-```bash# 1. Get the code
+```bash
+# 1. Get the code
 #    External contributors: fork on GitHub, then clone your fork:
 git clone https://github.com/<you>/open-kritt && cd open-kritt
 


### PR DESCRIPTION
## What & why

Fix the malformed Bash code fence in the contributor setup instructions so the language identifier and first comment render correctly.

## Type of change

- [x] `docs` — documentation only

## Affected components

- [x] docs / CI / tooling

## Checklist

By submitting this pull request, I agree to the [Contribution Terms](https://github.com/Kritt-ai/open-kritt/blob/main/CONTRIBUTION_TERMS.md), including assignment of my rights in the contribution.

- [x] Commits use Conventional Commits
- [x] Documentation checks pass
- [x] No secrets committed
- [x] Tests were not added because this is a Markdown-only formatting correction

## Checks

- `git diff --check`
- `cd docs-site && npm run check-links` (42 pages, 172 internal references, 1 redirect)

## Notes for reviewers

No related issue. This is a focused formatting-only correction.