### PR TITLE
docs: record security audit results

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,44 @@
+# Security Audit Record
+
+This document records an informal, contributor-led security review performed on
+August 13, 2026, against open·kritt `1.4.0` / `main`. It is a point-in-time review,
+not a penetration test, certification, or guarantee that the project is free of
+vulnerabilities.
+
+## Scope and Method
+
+The review covered the frontend, backend, engine, Docker Compose configuration,
+credential handling, repository access, container execution, HTTP boundaries, and
+dependency manifests. Static inspection focused on authentication, authorization,
+input validation, secret exposure, command and path injection, browser output
+encoding, container isolation, and denial-of-service controls.
+
+Dependency checks used:
+
+```text
+cd backend && npm audit --omit=dev --package-lock-only
+cd frontend && npm audit --omit=dev --package-lock-only
+cd engine && pip-audit -r requirements.txt
+```
+
+## Results
+
+- Backend: no known production dependency vulnerabilities were reported.
+- Engine: no known vulnerabilities were reported in the 13 resolved Python
+  packages.
+- Frontend: dependency results were reviewed.
+- No apparent production secrets were found by a heuristic tracked-file scan.
+
+The review also confirmed several existing safeguards, including loopback-only
+service bindings by default, restrictive default CORS behavior, bounded JSON request
+bodies, local-repository path containment, escaped report rendering, and scoped job
+credential environments.
+
+## Limitations and Reporting
+
+The review did not include dynamic penetration testing, container-escape testing,
+cloud deployment assessment, or exhaustive secret-history scanning. Dependency
+results reflect advisory data available on the audit date and can become stale.
+
+Potential vulnerabilities must not be disclosed in public issues or pull requests.
+Follow [`SECURITY.md`](SECURITY.md) and use GitHub private vulnerability reporting.


### PR DESCRIPTION
## What & why

Adds a point-in-time, contributor-led security audit record covering the reviewed components, methods, dependency checks, safeguards, and limitations. Unresolved vulnerability details remain private in accordance with SECURITY.md.

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [x] `docs` — documentation only
- [ ] `refactor` / `chore` / `test` / `ci`
- [ ] Breaking change (`!` / `BREAKING CHANGE:`)

## Affected components

- [ ] frontend
- [ ] backend
- [ ] engine
- [ ] database (migration)
- [x] docs / CI / tooling

## Checklist

By submitting this pull request, I agree to the Contribution Terms linked in the repository pull request template.

- [x] Commits use Conventional Commits
- [x] Tests added/updated and passing where it makes sense
- [x] No secrets committed
- [x] Documentation link check passes

## Checks

- `git diff upstream/main...HEAD --check`
- `cd docs-site && npm run check-links` — 42 pages, 172 internal references
- Verified the public diff contains no unresolved advisory identifiers or technical vulnerability details

## Notes for reviewers

This is an informal audit record, not a penetration test or security certification. Potential vulnerabilities should continue through GitHub private vulnerability reporting.