### PR TITLE
fix(frontend): update React Router security patch

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -4336,9 +4336,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4358,12 +4358,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
## What & why

Updates `react-router-dom` and its locked `react-router` dependency from 7.18.1 to 7.18.2 to consume the available security patch. The change is dependency-only and preserves the lockfile's cross-platform optional packages.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `chore` / `test` / `ci`
- [ ] Breaking change (`!` / `BREAKING CHANGE:`)

## Affected components

- [x] frontend
- [ ] backend
- [ ] engine
- [ ] database (migration)
- [ ] docs / CI / tooling

## Checklist

By submitting this pull request, I agree to the Contribution Terms linked in the repository pull request template.

- [x] Commits use Conventional Commits
- [x] Lint passes
- [x] Relevant tests pass
- [x] No secrets committed

## Verification

- `npm audit --omit=dev --package-lock-only` — 0 production vulnerabilities
- `npm run lint` — passed
- `npm test -- --exclude src/pages/Accounts.test.js` — 255/255 passed
- `npm run build` — passed
- `git diff upstream/main...HEAD --check` — passed

## Notes for reviewers

The full test suite has one pre-existing locale-sensitive failure in `Accounts.test.js` on Windows: the platform formats the date as `12 Aug 2026` while the assertion expects `Aug 12, 2026`. This dependency-only change does not touch that code. The production build emits the repository's existing chunk-size warning.