### PR TITLE
fix(engine): enforce selected OpenRouter model in Claude Code

### DIFF
--- a/engine/open_kritt_engine/harnesses.py
+++ b/engine/open_kritt_engine/harnesses.py
@@ -28,6 +28,7 @@ NON_RETRYABLE_HARNESS_FAILURES = frozenset(
         "model_unavailable",
         "quota_exceeded",
         "start_failed",
+        "unexpected_model_usage",
     }
 )
 CAPACITY_RATE_LIMIT_FAILURES = frozenset({"provider_throttled", "subagent_limited"})
@@ -81,6 +82,10 @@ HARNESS_FAILURE_MESSAGES = {
     "rate_limited": "The model provider is rate limiting generation requests. Wait and try again.",
     "start_failed": "The configured model harness could not be started. Rebuild or restart the engine and try again.",
     "timeout": "Generation timed out before the model provider returned a draft. Try again or choose a faster model.",
+    "unexpected_model_usage": (
+        "Claude Code reported use of a model other than the one selected for this scan. "
+        "The result was rejected and automatic retries were disabled to limit further charges."
+    ),
 }
 
 
@@ -104,6 +109,7 @@ class HarnessError(RuntimeError):
         exit_code: int | None = None,
         harness: str | None = None,
         retry_after_seconds: float | None = None,
+        usage: dict[str, Any] | None = None,
     ):
         super().__init__(message)
         self.output = output
@@ -115,6 +121,7 @@ class HarnessError(RuntimeError):
         self.exit_code = exit_code
         self.harness = harness
         self.retry_after_seconds = retry_after_seconds
+        self.usage = usage
         self.attempts: int | None = None
 
 
@@ -246,6 +253,7 @@ def _harness_error_with_output(exc: BaseException, output: HarnessOutput) -> Har
             exit_code=exc.exit_code,
             harness=exc.harness,
             retry_after_seconds=exc.retry_after_seconds,
+            usage=exc.usage,
         )
     return HarnessError(str(exc), output=output)
 
@@ -851,6 +859,9 @@ def _scan_docker_command(
         "ANTHROPIC_API_KEY",
         "CODEX_MODEL_PROVIDER",
         "CLAUDE_CODE_MODEL_PROVIDER",
+        "CLAUDE_CODE_SUBAGENT_MODEL",
+        "CLAUDE_CODE_NO_MODEL_FALLBACK",
+        "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK",
         "CURSOR_API_KEY",
         "CURSOR_AUTH_TOKEN",
         "CURSOR_AGENT_BIN",
@@ -1002,6 +1013,14 @@ def _claude_env(env: dict[str, str], model: str, model_provider: str | None = No
         actual_env["ANTHROPIC_BASE_URL"] = actual_env.get("ANTHROPIC_BASE_URL") or OPENROUTER_CLAUDE_BASE_URL
         actual_env["ANTHROPIC_AUTH_TOKEN"] = actual_env.get("ANTHROPIC_AUTH_TOKEN") or actual_env["OPENROUTER_API_KEY"]
         actual_env["ANTHROPIC_API_KEY"] = ""
+        selected_model = _claude_model_name(model, actual_env, model_provider)
+        # Claude Code's Agent tool can request a different model than the
+        # parent --model value. Force every subagent to the explicit OpenRouter
+        # selection and disable internal model fallback so a scan cannot
+        # silently cross provider/model price boundaries.
+        actual_env["CLAUDE_CODE_SUBAGENT_MODEL"] = selected_model
+        actual_env["CLAUDE_CODE_NO_MODEL_FALLBACK"] = "1"
+        actual_env["CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK"] = "1"
     return actual_env
 
 
@@ -1126,11 +1145,12 @@ def _extract_json_from_output_file(path: str) -> dict[str, Any]:
 
 
 def _extract_json_from_claude_stream(
-    stdout: str, *, provider: str | None = None
+    stdout: str, *, provider: str | None = None, expected_model: str | None = None
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     candidates: list[str] = []
     usage = None
     stream_error = None
+    model_switch_event = None
     for line in stdout.splitlines():
         if not line.strip():
             continue
@@ -1157,6 +1177,22 @@ def _extract_json_from_claude_stream(
                 candidates.append(event["result"])
         if event.get("type") == "error":
             stream_error = json.dumps(event.get("error") or event)
+        if event.get("type") == "system" and event.get("subtype") in {
+            "model_fallback",
+            "model_refusal_fallback",
+            "server_fallback",
+        }:
+            model_switch_event = event.get("subtype")
+
+    if model_switch_event:
+        raise HarnessError(
+            f"Claude Code reported an internal model switch ({model_switch_event}).",
+            code="unexpected_model_usage",
+            harness="claude-code",
+            usage=usage,
+        )
+    if expected_model:
+        _validate_claude_model_usage(usage, expected_model)
 
     last_error = None
     for candidate in reversed(candidates):
@@ -1171,6 +1207,34 @@ def _extract_json_from_claude_stream(
         code="invalid_output",
         harness="claude-code",
     ) from last_error
+
+
+def _claude_usage_model_name(model: str) -> str:
+    """Remove Claude Code's context-window annotation from a usage key."""
+
+    return re.sub(r"\[1m\]$", "", model.strip(), flags=re.IGNORECASE).casefold()
+
+
+def _validate_claude_model_usage(usage: dict[str, Any] | None, expected_model: str) -> None:
+    """Fail closed when Claude Code reports billing against another model."""
+
+    if not isinstance(usage, dict):
+        return
+    model_usage = usage.get("modelUsage")
+    if not isinstance(model_usage, dict):
+        return
+    expected = _claude_usage_model_name(expected_model)
+    unexpected = sorted(
+        str(model) for model in model_usage if isinstance(model, str) and _claude_usage_model_name(model) != expected
+    )
+    if not unexpected:
+        return
+    raise HarnessError(
+        f"Claude Code reported unexpected model usage ({', '.join(unexpected)}); expected {expected_model}.",
+        code="unexpected_model_usage",
+        harness="claude-code",
+        usage=usage,
+    )
 
 
 def _collect_json_text_candidates(value: Any) -> list[str]:
@@ -1744,7 +1808,11 @@ class ClaudeHarness:
         process_output = _process_output(proc)
         if provider == "openrouter":
             try:
-                payload, usage = _extract_json_from_claude_stream(proc.stdout, provider=provider)
+                payload, usage = _extract_json_from_claude_stream(
+                    proc.stdout,
+                    provider=provider,
+                    expected_model=model,
+                )
             except HarnessError as exc:
                 raise _harness_error_with_output(exc, process_output) from exc
             except json.JSONDecodeError as exc:

--- a/engine/open_kritt_engine/post_processing.py
+++ b/engine/open_kritt_engine/post_processing.py
@@ -45,7 +45,16 @@ IMPACT_LEVELS = {"critical", "high", "medium", "low", "informational"}
 
 
 class PostProcessExecutionError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        usage: dict[str, Any] | None = None,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.usage = usage
 
 
 class PostProcessRateLimited(PostProcessExecutionError):
@@ -628,6 +637,8 @@ class PostProcessor:
                     return result.payload, usage, codex_session_id, checked_out_commit
                 except (HarnessError, OutputValidationError, ValueError) as exc:
                     last_exception = exc
+                    if isinstance(exc, HarnessError) and exc.usage is not None:
+                        usage = exc.usage
                     detail = (
                         f"{exc.public_message} Diagnostic: {exc.code}." if isinstance(exc, HarnessError) else str(exc)
                     )
@@ -693,8 +704,10 @@ class PostProcessor:
                     limit_kind=last_exception.code,
                 )
             raise PostProcessExecutionError(
-                last_error or "The model process exited before post-processing returned a structured result."
-            )
+                last_error or "The model process exited before post-processing returned a structured result.",
+                code=getattr(last_exception, "code", None),
+                usage=usage,
+            ) from last_exception
         except ClaudeCredentialRateLimited as exc:
             with self.db.connect() as conn:
                 self.db.update_post_process_metadata(
@@ -803,7 +816,7 @@ class PostProcessor:
                     status="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                     error=str(exc),
                     run_time_ms=run_time_ms,
-                    raw_token_usage=None,
+                    raw_token_usage=getattr(exc, "usage", None),
                     phase="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                 )
                 conn.commit()
@@ -892,7 +905,7 @@ class PostProcessor:
                     status="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                     error=str(exc),
                     run_time_ms=run_time_ms,
-                    raw_token_usage=None,
+                    raw_token_usage=getattr(exc, "usage", None),
                     phase="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                 )
                 conn.commit()
@@ -1052,7 +1065,7 @@ class PostProcessor:
                     status="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                     error=str(exc),
                     run_time_ms=run_time_ms,
-                    raw_token_usage=None,
+                    raw_token_usage=getattr(exc, "usage", None),
                     phase="interrupted" if isinstance(exc, PostProcessRateLimited) else "failed",
                 )
                 conn.commit()

--- a/engine/open_kritt_engine/worker.py
+++ b/engine/open_kritt_engine/worker.py
@@ -93,7 +93,9 @@ ARTIFACT_CLEANUP_GRACE_SECONDS = 5 * 60.0
 
 
 class StepExecutionError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, code: str | None = None):
+        super().__init__(message)
+        self.code = code
 
 
 class RateLimitExhausted(StepExecutionError):
@@ -864,9 +866,19 @@ class Worker:
                 return True
             except Exception as exc:
                 task_finished = True
-                LOGGER.exception("scan %s failed", scan["id"])
+                unexpected_model_usage = getattr(exc, "code", None) == "unexpected_model_usage"
+                failure_status = "paused" if unexpected_model_usage else "failed"
+                failure_error = (
+                    f"{exc.public_message} Diagnostic: {exc.code}." if isinstance(exc, HarnessError) else str(exc)
+                )
+                LOGGER.exception("scan %s %s", scan["id"], failure_status)
                 with self.db.connect() as conn:
-                    self.db.set_scan_status_if_active(conn, int(scan["id"]), "failed", error=str(exc))
+                    self.db.set_scan_status_if_active(
+                        conn,
+                        int(scan["id"]),
+                        failure_status,
+                        error=failure_error,
+                    )
                     conn.commit()
                 return True
             self._record_scan_claim_result(int(scan["id"]), did_work=did_work)
@@ -1075,6 +1087,7 @@ class Worker:
                     generation_id,
                     error=error,
                     validation_errors=validation_errors,
+                    raw_token_usage=exc.usage if isinstance(exc, HarnessError) else None,
                 )
                 return
 
@@ -1140,14 +1153,20 @@ class Worker:
         *,
         error: str,
         validation_errors: list[dict[str, str]] | None = None,
+        raw_token_usage: dict[str, Any] | None = None,
     ) -> bool:
         try:
             with self.db.connect() as conn:
+                failure_details: dict[str, Any] = {
+                    "error": error,
+                    "validation_errors": validation_errors,
+                }
+                if raw_token_usage is not None:
+                    failure_details["raw_token_usage"] = raw_token_usage
                 failed = self.db.fail_generation(
                     conn,
                     generation_id,
-                    error=error,
-                    validation_errors=validation_errors,
+                    **failure_details,
                 )
                 conn.commit()
             return failed
@@ -1518,6 +1537,8 @@ class Worker:
                     return True
                 except (HarnessError, OutputValidationError, ValueError) as exc:
                     last_exception = exc
+                    if isinstance(exc, HarnessError) and exc.usage is not None:
+                        usage = exc.usage
                     if isinstance(exc, HarnessError):
                         last_error = f"{exc.public_message} Diagnostic: {exc.code}."
                     else:
@@ -1634,7 +1655,10 @@ class Worker:
                     account_home=getattr(prepared.workspace, "provider_account_home", None),
                     limit_kind=last_exception.code,
                 )
-            raise StepExecutionError(f"step {step.id} {failure_summary}")
+            raise StepExecutionError(
+                f"step {step.id} {failure_summary}",
+                code=getattr(last_exception, "code", None),
+            ) from last_exception
         finally:
             if metadata_id is not None:
                 if prepared is not None:

--- a/engine/tests/test_engine.py
+++ b/engine/tests/test_engine.py
@@ -1214,6 +1214,7 @@ def test_claude_harness_uses_dangerous_permissions_and_default_tools(monkeypatch
 
     def fake_run_process(cmd, prompt, cwd, timeout, env=None):
         captured["cmd"] = cmd
+        captured["env"] = env
         captured["timeout"] = timeout
         return SimpleNamespace(
             stdout=json.dumps(
@@ -1259,6 +1260,9 @@ def test_claude_harness_uses_dangerous_permissions_and_default_tools(monkeypatch
     assert "--append-system-prompt" in captured["cmd"]
     assert "--no-session-persistence" in captured["cmd"]
     assert "--permission-mode" not in captured["cmd"]
+    assert "CLAUDE_CODE_SUBAGENT_MODEL" not in captured["env"]
+    assert "CLAUDE_CODE_NO_MODEL_FALLBACK" not in captured["env"]
+    assert "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK" not in captured["env"]
     claude_schema = json.loads(captured["cmd"][captured["cmd"].index("--json-schema") + 1])
     assert source_schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
     assert "$schema" not in claude_schema
@@ -1310,6 +1314,9 @@ def test_claude_harness_can_route_glm_through_openrouter(monkeypatch, tmp_path):
             "CLAUDE_CONFIG_DIR": str(tmp_path / "home" / ".claude"),
             "OPENROUTER_API_KEY": "or-key",
             "CODEX_MODEL_PROVIDER": "openrouter",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
+            "CLAUDE_CODE_NO_MODEL_FALLBACK": "0",
+            "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK": "0",
         },
     )
 
@@ -1318,6 +1325,9 @@ def test_claude_harness_can_route_glm_through_openrouter(monkeypatch, tmp_path):
     assert captured["env"]["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
     assert captured["env"]["ANTHROPIC_AUTH_TOKEN"] == "or-key"
     assert captured["env"]["ANTHROPIC_API_KEY"] == ""
+    assert captured["env"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "z-ai/glm-5.2"
+    assert captured["env"]["CLAUDE_CODE_NO_MODEL_FALLBACK"] == "1"
+    assert captured["env"]["CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK"] == "1"
     # The subprocess environment is authoritative in both containers and local
     # development; credentials must never be serialized into process arguments.
     if captured["cmd"][:3] == ["runuser", "-u", "nobody"]:
@@ -1330,6 +1340,89 @@ def test_claude_harness_can_route_glm_through_openrouter(monkeypatch, tmp_path):
     assert "--append-system-prompt" in captured["cmd"]
     assert "--json-schema" not in captured["cmd"]
     assert harnesses.claude_model_provider("glm-5.2", captured["env"]) == "openrouter"
+
+
+def test_claude_openrouter_rejects_unexpected_model_usage(monkeypatch, tmp_path):
+    raw_stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "result",
+                    "result": "not structured JSON",
+                    "usage": {"input_tokens": 3},
+                    "total_cost_usd": 1.25,
+                    "modelUsage": {
+                        "z-ai/glm-5.2": {"inputTokens": 1},
+                        "claude-opus-4-8[1m]": {"inputTokens": 2},
+                    },
+                }
+            )
+        ]
+    )
+
+    monkeypatch.setattr(
+        harnesses,
+        "_run_process",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout=raw_stdout, stderr="", returncode=0),
+    )
+
+    with pytest.raises(HarnessError) as raised:
+        ClaudeHarness(timeout_seconds=5, model_provider="openrouter").run(
+            prompt="prompt",
+            schema=output_schema('{"thing":"string"}', multi_output=False),
+            repo_dir="/tmp",
+            model="glm-5.2",
+            env={
+                "HOME": str(tmp_path / "home"),
+                "OPENROUTER_API_KEY": "or-key",
+            },
+        )
+
+    assert raised.value.code == "unexpected_model_usage"
+    assert raised.value.retryable is False
+    assert harnesses.harness_failure_retry_count(raised.value, retry_count=5, cyber_safety_retry_count=5) == 0
+    assert raised.value.usage["total_cost_usd"] == 1.25
+    assert "claude-opus-4-8[1m]" in str(raised.value)
+    assert raised.value.output.stdout == raw_stdout
+
+
+def test_claude_openrouter_rejects_model_fallback_event(monkeypatch, tmp_path):
+    raw_stdout = "\n".join(
+        [
+            json.dumps({"type": "system", "subtype": "model_refusal_fallback"}),
+            json.dumps({"type": "result", "result": "not structured JSON"}),
+        ]
+    )
+    monkeypatch.setattr(
+        harnesses,
+        "_run_process",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout=raw_stdout, stderr="", returncode=0),
+    )
+
+    with pytest.raises(HarnessError) as raised:
+        ClaudeHarness(timeout_seconds=5, model_provider="openrouter").run(
+            prompt="prompt",
+            schema=output_schema('{"thing":"string"}', multi_output=False),
+            repo_dir="/tmp",
+            model="glm-5.2",
+            env={"HOME": str(tmp_path / "home"), "OPENROUTER_API_KEY": "or-key"},
+        )
+
+    assert raised.value.code == "unexpected_model_usage"
+    assert raised.value.retryable is False
+    assert "model_refusal_fallback" in str(raised.value)
+    assert raised.value.output.stdout == raw_stdout
+
+
+def test_claude_model_usage_accepts_selected_model_context_annotation():
+    harnesses._validate_claude_model_usage(
+        {"modelUsage": {"z-ai/glm-5.2[1m]": {"inputTokens": 1}}},
+        "z-ai/glm-5.2",
+    )
+    harnesses._validate_claude_model_usage(
+        {"modelUsage": {"~deepseek/deepseek-v4-flash-latest": {"inputTokens": 1}}},
+        "~deepseek/deepseek-v4-flash-latest",
+    )
 
 
 def test_claude_openrouter_parse_error_carries_raw_output(monkeypatch, tmp_path):
@@ -2838,6 +2931,7 @@ def test_worker_does_not_retry_permanent_harness_failures(monkeypatch, tmp_path)
                 "provider response contained secret-value",
                 code="quota_exceeded",
                 harness="claude-code",
+                usage={"total_tokens": 7},
             )
 
     prepared = SimpleNamespace(
@@ -2862,6 +2956,7 @@ def test_worker_does_not_retry_permanent_harness_failures(monkeypatch, tmp_path)
     assert fake_harness.calls == 1
     assert "account quota is exhausted" in fake_db.metadata[0]["error"]
     assert "Diagnostic: quota_exceeded" in fake_db.metadata[0]["error"]
+    assert fake_db.metadata[1]["raw_token_usage"] == {"total_tokens": 7}
     assert "secret-value" not in fake_db.metadata[0]["error"]
     assert not root.exists()
 
@@ -3072,6 +3167,7 @@ def test_post_processing_does_not_retry_permanent_harness_failures(monkeypatch, 
                 "provider response contained secret-value",
                 code="quota_exceeded",
                 harness="claude-code",
+                usage={"total_tokens": 13},
             )
 
     prepared = SimpleNamespace(
@@ -3086,7 +3182,7 @@ def test_post_processing_does_not_retry_permanent_harness_failures(monkeypatch, 
     processor = PostProcessor(SimpleNamespace(retry_count=2, data_dir="/tmp", github_token=None), fake_db)
     fake_harness = PermanentFailureHarness()
 
-    with pytest.raises(post_processing_module.PostProcessExecutionError, match="quota_exceeded"):
+    with pytest.raises(post_processing_module.PostProcessExecutionError, match="quota_exceeded") as raised:
         processor._run_harness_with_retries(
             metadata_id=9,
             scan=scan(),
@@ -3097,7 +3193,10 @@ def test_post_processing_does_not_retry_permanent_harness_failures(monkeypatch, 
         )
 
     assert fake_harness.calls == 1
+    assert raised.value.code == "quota_exceeded"
+    assert raised.value.usage == {"total_tokens": 13}
     assert "account quota is exhausted" in fake_db.updates[-1]["error"]
+    assert fake_db.updates[-1]["raw_token_usage"] == {"total_tokens": 13}
     assert "secret-value" not in fake_db.updates[-1]["error"]
     assert not root.exists()
 

--- a/engine/tests/test_generation.py
+++ b/engine/tests/test_generation.py
@@ -1447,6 +1447,7 @@ def test_worker_records_actionable_harness_failure_without_provider_detail(caplo
         code="invalid_output_schema",
         exit_code=1,
         harness="codex",
+        usage={"total_tokens": 11},
     )
     harness_error.attempts = 1
     fake_db = FakeDb()
@@ -1465,6 +1466,7 @@ def test_worker_records_actionable_harness_failure_without_provider_detail(caplo
     assert "model=gpt-test" in caplog.text
     assert "attempts=1" in caplog.text
     assert provider_detail not in caplog.text
+    assert fake_db.failed[0][1]["raw_token_usage"] == {"total_tokens": 11}
 
 
 def test_worker_marks_generation_failed_when_completed_result_cannot_be_serialized(tmp_path):

--- a/engine/tests/test_provider_credentials.py
+++ b/engine/tests/test_provider_credentials.py
@@ -111,6 +111,9 @@ def test_job_environment_only_includes_selected_provider_and_harness_credentials
         "ANTHROPIC_API_KEY": "anthropic-secret",
         "OPENROUTER_API_KEY": "openrouter-secret",
         "CURSOR_API_KEY": "cursor-secret",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
+        "CLAUDE_CODE_NO_MODEL_FALLBACK": "0",
+        "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK": "0",
     }
 
     codex = job_environment("codex", "codex", source)
@@ -127,3 +130,6 @@ def test_job_environment_only_includes_selected_provider_and_harness_credentials
     for env in (codex, openrouter_claude, openrouter_cursor):
         assert "DATABASE_URL" not in env
         assert "GITHUB_TOKEN" not in env
+        assert "CLAUDE_CODE_SUBAGENT_MODEL" not in env
+        assert "CLAUDE_CODE_NO_MODEL_FALLBACK" not in env
+        assert "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK" not in env

--- a/engine/tests/test_security_hardening.py
+++ b/engine/tests/test_security_hardening.py
@@ -155,6 +155,34 @@ def test_snapshot_scan_runner_uses_image_workspace_without_host_workspace_mount(
     assert command[command.index("open-kritt-workspace-snapshot:test") + 1 :][:2] == ["codex", "exec"]
 
 
+def test_scan_runner_forwards_claude_model_lock_environment(monkeypatch, tmp_path):
+    data_dir = tmp_path / "engine-data"
+    host_data_dir = tmp_path / "host-engine-data"
+    repo_dir = data_dir / "jobs" / "metadata-779" / "workspace"
+    home_dir = data_dir / "jobs" / "metadata-779" / "home"
+    repo_dir.mkdir(parents=True)
+    home_dir.mkdir(parents=True)
+    monkeypatch.setenv("ENGINE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("ENGINE_DOCKER_DATA_DIR_HOST", str(host_data_dir))
+    monkeypatch.setattr(harnesses.shutil, "which", lambda name: "docker" if name == "docker" else None)
+
+    model_lock = {
+        "CLAUDE_CODE_SUBAGENT_MODEL": "~deepseek/deepseek-v4-flash-latest",
+        "CLAUDE_CODE_NO_MODEL_FALLBACK": "1",
+        "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK": "1",
+    }
+    command = REAL_SCAN_DOCKER_COMMAND(
+        ["claude", "-p", "--model", model_lock["CLAUDE_CODE_SUBAGENT_MODEL"]],
+        str(repo_dir),
+        {"HOME": str(home_dir), **model_lock},
+    )
+
+    inherited_keys = {
+        command[index + 1] for index, value in enumerate(command) if value == "--env" and "=" not in command[index + 1]
+    }
+    assert model_lock.keys() <= inherited_keys
+
+
 def test_prewarm_rebuilds_previous_marker_version_instead_of_promoting_it(monkeypatch, tmp_path):
     stale_base = tmp_path / "cache" / "owner__repo@HEAD"
     stale_repo = stale_base / "owner__repo"

--- a/engine/tests/test_worker_backoff.py
+++ b/engine/tests/test_worker_backoff.py
@@ -45,6 +45,7 @@ def test_engine_config_reads_scan_storage_floor(monkeypatch, tmp_path):
 class _ScanDatabase:
     def __init__(self, *, claimed):
         self.claimed = claimed
+        self.statuses = []
         self.scan = {
             "id": 58,
             "workflow_id": 2,
@@ -74,6 +75,11 @@ class _ScanDatabase:
 
     def load_step_results(self, _conn, _scan_id):
         return []
+
+    def set_scan_status_if_active(self, _conn, scan_id, status, error=None):
+        self.statuses.append((scan_id, status, error))
+        self.scan["status"] = status
+        return True
 
 
 def _worker(db):
@@ -143,6 +149,28 @@ def test_worker_still_claims_pending_work_on_an_already_running_scan(monkeypatch
     assert worker.run_scan_once(worker_id=2) is True
     assert calls == [pending_job]
     assert cleanup_requests == [True]
+
+
+def test_unexpected_model_usage_pauses_scan_instead_of_allowing_auto_resume():
+    db = _ScanDatabase(claimed=set())
+    worker = _worker(db)
+    worker.process_scan = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        worker_module.StepExecutionError(
+            "step failed after 1 attempt: Claude Code changed models.",
+            code="unexpected_model_usage",
+        )
+    )
+    worker._schedule_post_task_cleanup = lambda: None
+
+    assert worker.run_scan_once(worker_id=2) is True
+
+    assert db.statuses == [
+        (
+            58,
+            "paused",
+            "step failed after 1 attempt: Claude Code changed models.",
+        )
+    ]
 
 
 class _RateLimitDatabase:


### PR DESCRIPTION
<!--
Thanks for contributing to open·kritt! Please fill this out so reviewers can move fast.
Keep PRs focused and small where possible.
-->

## What & why

Ensure Claude Code scans routed through OpenRouter remain on the model selected in the scan configuration.

Open-kritt previously passed the selected model to the top-level Claude Code process. Claude Code subagents and internal fallback paths could still select another model. This change pins subagents to the configured model, disables fallback, and rejects results that report unexpected model usage.

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] engine

## Checklist

- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (no empty `()` scope)
- [x] Lint & format pass (`npm run lint` / `ruff check .`)
- [x] Tests added/updated and passing where it makes sense
- [x] No secrets committed
