### PR TITLE
fix(compose): separate engine and runner image tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ ENGINE_SCAN_CACHE_RETENTION_DAYS=0
 # Absolute Docker-host path corresponding to ENGINE_DATA_DIR. Compose derives
 # the default from ${PWD}; set this explicitly if ENGINE_DATA_DIR_HOST changes.
 ENGINE_DOCKER_DATA_DIR_HOST=
+# Image built and run for the long-lived engine service.
+ENGINE_IMAGE=open-kritt-engine:local
+# Image used for isolated jobs. Set a different tag for a custom toolchain image.
 ENGINE_SCAN_RUNNER_IMAGE=open-kritt-engine:local
 # Accounts and the CLI mirror the OpenRouter key here for live services while
 # keeping .env synchronized for future Compose runs. Both files use mode 0600.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     build:
       context: ./engine
       dockerfile: Dockerfile
-    image: ${ENGINE_SCAN_RUNNER_IMAGE:-open-kritt-engine:local}
+    image: ${ENGINE_IMAGE:-open-kritt-engine:local}
     container_name: open-kritt-engine
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://open_kritt:open_kritt_password@db:5432/open_kritt?schema=public}

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -584,6 +584,27 @@ test('start blocks GitHub-only configuration and launches Compose with model acc
   assert.equal((await stat(join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex'))).mode & 0o777, 0o700);
 });
 
+test('Compose configures the engine service image independently from job images', async () => {
+  const compose = await readFile(new URL('../docker-compose.yml', import.meta.url), 'utf8');
+  const engineStart = compose.indexOf('\n  engine:\n');
+  const engineEnd = compose.indexOf('\n  executor-view:\n', engineStart);
+
+  assert.notEqual(engineStart, -1);
+  assert.notEqual(engineEnd, -1);
+
+  const engineService = compose.slice(engineStart, engineEnd);
+  assert.match(engineService, /^    image: \$\{ENGINE_IMAGE:-open-kritt-engine:local\}$/m);
+  assert.match(
+    engineService,
+    /^      ENGINE_SCAN_RUNNER_IMAGE: \$\{ENGINE_SCAN_RUNNER_IMAGE:-open-kritt-engine:local\}$/m
+  );
+  assert.doesNotMatch(engineService, /^    image: \$\{ENGINE_SCAN_RUNNER_IMAGE:/m);
+
+  const environmentTemplate = await readFile(new URL('../.env.example', import.meta.url), 'utf8');
+  assert.match(environmentTemplate, /^ENGINE_IMAGE=open-kritt-engine:local$/m);
+  assert.match(environmentTemplate, /^ENGINE_SCAN_RUNNER_IMAGE=open-kritt-engine:local$/m);
+});
+
 test('start reports how to repair a Codex home parent left unwritable by Docker', async (t) => {
   if (typeof process.getuid === 'function' && process.getuid() === 0) {
     t.skip('root bypasses directory permission checks');


### PR DESCRIPTION
## What & why

The engine service and its isolated job image currently share the `ENGINE_SCAN_RUNNER_IMAGE` setting. Selecting a custom job image therefore also retags the engine build and can overwrite that custom image.

This change introduces `ENGINE_IMAGE` for the engine service while keeping `ENGINE_SCAN_RUNNER_IMAGE` dedicated to isolated jobs. Both retain the existing default tag, so standard installations remain unchanged.

Closes #42

## Type of change

- [x] `fix` — bug fix

## Affected components

- [x] Docker Compose configuration
- [x] CLI regression tests

## Safety

- Existing default behavior is preserved.
- The regression test reads tracked configuration only and uses no runtime data.
- No containers, images, credentials, database data, or external resources are modified by the test.

## Checks

- `node --test scripts/kritt.test.mjs scripts/kritt-ui.test.mjs scripts/kritt-headless.test.mjs`
- `docker compose config` with distinct synthetic image tags and with defaults
- `prettier --check docker-compose.yml scripts/kritt.test.mjs`
- `node scripts/sync-version.mjs --check`
- `git diff --check`