### PR TITLE
fix(cli): report an unusable Docker before login and start

### DIFF
--- a/docs-site/getting-started/installation-and-setup.mdx
+++ b/docs-site/getting-started/installation-and-setup.mdx
@@ -10,7 +10,7 @@ the stack. It does not need an npm install step.
 ## Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/), or Docker Engine with
-  the Docker Compose plugin
+  the Docker Compose plugin, version 2.13.0 or newer (`docker compose version`)
 - Git
 - Node.js 20 or newer for the repository-local CLI
 
@@ -70,6 +70,21 @@ user:
 docker info >/dev/null
 docker compose version
 ```
+
+### The Docker preflight check
+
+`./kritt start` and both guided logins verify Docker before they run anything, and stop
+with the reason when they cannot:
+
+| Reported problem | What to do |
+| --- | --- |
+| The Docker daemon is not reachable | Start Docker Desktop or the `docker` service. When more than one Docker is installed, check that `docker context ls` selects the running one. |
+| The Docker Compose plugin is not available | Install the Compose plugin, or Docker Desktop, and confirm `docker compose version` works. |
+| Docker Compose is too old | Update Docker. The guided logins run `docker compose run --build`, which needs Compose 2.13.0 or newer. |
+| Docker Compose could not read this project | Usually an outdated Compose that cannot parse `docker-compose.yml`; the message quotes the value it rejected. Update Docker, or correct the reported `docker-compose.yml` or `.env` entry. |
+
+Before this check existed, a stopped or outdated Docker surfaced only as a login that
+saved nothing.
 
 If Docker requires `sudo`, configure [non-root Docker access](https://docs.docker.com/engine/install/linux-postinstall/)
 or use [rootless Docker](https://docs.docker.com/engine/security/rootless/) before running
@@ -162,7 +177,7 @@ credential, how it is billed, which harness it enables, and how to verify it.
 | --- | --- |
 | `./kritt` | Open the full-screen interactive menu. Arrow keys navigate, Enter selects, and Esc or Ctrl+C exits. |
 | `./kritt setup` | Create `.env` when needed and configure model access or the optional GitHub token. |
-| `./kritt start` | Check setup, then run `docker compose up --build`. Ctrl+C stops the attached stack. |
+| `./kritt start` | Check setup and Docker, then run `docker compose up --build`. Ctrl+C stops the attached stack. |
 | `./kritt help` | Show command guidance. Use `./kritt help setup` or `./kritt help start` for a specific command. |
 | `./kritt-headless` | Operate a running stack without the web UI: import resources, create and inspect scans, configure settings, and export results. |
 | `./kritt-headless help` | Show headless interactive and command-mode usage. |

--- a/scripts/kritt-lib.mjs
+++ b/scripts/kritt-lib.mjs
@@ -15,6 +15,11 @@ const CODEX_LOGIN_CONTAINER_USER_HOME = '/open-kritt-login';
 const CODEX_LOGIN_CONTAINER_HOME = `${CODEX_LOGIN_CONTAINER_USER_HOME}/.codex`;
 const CODEX_LOGIN_CONTAINER_BOOTSTRAP =
   'umask 077; mkdir -p "$HOME" "$CODEX_HOME" && chmod 700 "$HOME" "$CODEX_HOME" && exec codex "$@"';
+const MAX_CAPTURED_OUTPUT = 64 * 1024;
+const DOCKER_INSTALL_HINT = 'Install Docker Desktop, or Docker Engine with the Docker Compose plugin, then try again.';
+
+// `docker compose run --build` backs both guided logins and arrived in Compose 2.13.0.
+export const MINIMUM_COMPOSE_VERSION = '2.13.0';
 
 export const ENVIRONMENT_ITEMS = [
   {
@@ -756,6 +761,17 @@ export function createPrompter(io) {
 export async function runCommand(command, args, options = {}) {
   return new Promise((resolveCommand, rejectCommand) => {
     const child = spawn(command, args, { cwd: options.cwd, stdio: options.stdio || 'inherit' });
+    const captured = { stdout: '', stderr: '' };
+    const capture = (stream, key) => {
+      if (!stream) return;
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk) => {
+        if (captured[key].length >= MAX_CAPTURED_OUTPUT) return;
+        captured[key] = `${captured[key]}${chunk}`.slice(0, MAX_CAPTURED_OUTPUT);
+      });
+    };
+    capture(child.stdout, 'stdout');
+    capture(child.stderr, 'stderr');
     const abortSignal = options.signal;
     const removeAbortListener = () => abortSignal?.removeEventListener('abort', onAbort);
     const onAbort = () => {
@@ -770,7 +786,7 @@ export async function runCommand(command, args, options = {}) {
     });
     child.once('close', (code, signal) => {
       removeAbortListener();
-      resolveCommand({ code: code ?? 1, signal });
+      resolveCommand({ code: code ?? 1, signal, ...captured });
     });
   });
 }
@@ -924,7 +940,106 @@ async function removeLoginContainer(runner, rootDir, containerName, io) {
   }
 }
 
+function versionNumbers(text) {
+  const match = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(text || '');
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)] : null;
+}
+
+function isOlderVersion(candidate, minimum) {
+  for (let index = 0; index < minimum.length; index += 1) {
+    const left = candidate[index] ?? 0;
+    const right = minimum[index] ?? 0;
+    if (left !== right) return left < right;
+  }
+  return false;
+}
+
+function firstLine(text) {
+  return (text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+}
+
+// Docker prints the useful part of a failure on the first line; keep it as a sentence so
+// issue messages stay readable both in the plain CLI and in a fullscreen notice.
+function commandDetail(result) {
+  const line = firstLine(result?.stderr) || firstLine(result?.stdout);
+  if (!line) return '';
+  const detail = line.replace(/\s+/g, ' ').slice(0, 300);
+  return /[.!?]$/.test(detail) ? `${detail} ` : `${detail}. `;
+}
+
+/**
+ * Verifies the Docker environment this project actually needs: a reachable daemon, a
+ * Compose plugin new enough for the flags the CLI passes, and a Compose project the
+ * plugin can parse. Without it, an old or stopped Docker surfaces as an unexplained
+ * login or startup failure.
+ */
+export async function checkDockerEnvironment({ rootDir, runner = runCommand } = {}) {
+  const issues = [];
+  const probe = (args) => runner('docker', args, { cwd: rootDir, stdio: 'pipe' });
+  let serverVersion = null;
+  let composeVersion = null;
+
+  try {
+    const daemon = await probe(['version', '--format', '{{.Server.Version}}']);
+    serverVersion = daemon.code === 0 ? firstLine(daemon.stdout) || null : null;
+    if (daemon.code !== 0) {
+      issues.push({
+        code: 'daemon_unreachable',
+        message: `The Docker daemon is not reachable. ${commandDetail(daemon)}Start Docker Desktop or the docker service, and check "docker context ls" when more than one Docker is installed.`,
+      });
+    }
+
+    const compose = await probe(['compose', 'version', '--short']);
+    if (compose.code !== 0) {
+      issues.push({
+        code: 'compose_missing',
+        message: `The Docker Compose plugin is not available. ${commandDetail(compose)}${DOCKER_INSTALL_HINT}`,
+      });
+      return { ok: false, issues, serverVersion, composeVersion };
+    }
+
+    composeVersion = (firstLine(compose.stdout) || '').replace(/^v/, '') || null;
+    const numbers = versionNumbers(composeVersion);
+    if (numbers && isOlderVersion(numbers, versionNumbers(MINIMUM_COMPOSE_VERSION))) {
+      issues.push({
+        code: 'compose_outdated',
+        message: `Docker Compose ${composeVersion} is too old for open-kritt, which needs ${MINIMUM_COMPOSE_VERSION} or newer: the guided logins run "docker compose run --build". Update Docker, then try again.`,
+      });
+      return { ok: false, issues, serverVersion, composeVersion };
+    }
+
+    const project = await probe(['compose', 'config', '-q']);
+    if (project.code !== 0) {
+      issues.push({
+        code: 'project_invalid',
+        message: `Docker Compose could not read this project. ${commandDetail(project)}Update Docker Compose to a current release, or correct the reported docker-compose.yml or .env value, then try again.`,
+      });
+    }
+  } catch (error) {
+    issues.push({ code: 'docker_missing', message: `${error.message}. ${DOCKER_INSTALL_HINT}` });
+  }
+
+  return { ok: issues.length === 0, issues, serverVersion, composeVersion };
+}
+
+export function dockerEnvironmentMessage(preflight) {
+  return preflight.issues.map((issue) => issue.message).join(' ');
+}
+
+async function dockerEnvironmentBlocked({ io, rootDir, runner }) {
+  const preflight = await checkDockerEnvironment({ rootDir, runner });
+  if (preflight.ok) return null;
+  for (const issue of preflight.issues) writeError(io, issue.message);
+  return preflight;
+}
+
 export async function saveDockerCodexLogin({ io, rootDir, runner = runCommand, signalSource = process, targetPath }) {
+  const blocked = await dockerEnvironmentBlocked({ io, rootDir, runner });
+  if (blocked) return failedAuthResult('docker_unavailable', dockerEnvironmentMessage(blocked));
+
   const directoryResult = await ensureCodexHomeDirectory(dirname(targetPath), rootDir);
   if (!directoryResult.ok) {
     writeError(io, directoryResult.message);
@@ -1031,6 +1146,8 @@ export async function saveDockerCodexLogin({ io, rootDir, runner = runCommand, s
 }
 
 export async function saveDockerClaudeLogin({ io, rootDir, runner = runCommand, home }) {
+  if (await dockerEnvironmentBlocked({ io, rootDir, runner })) return false;
+
   await mkdir(home, { recursive: true, mode: 0o700 });
   write(
     io,
@@ -1234,6 +1351,8 @@ export async function runStart(options = {}) {
     return 1;
   }
 
+  if (await dockerEnvironmentBlocked(context)) return 1;
+
   write(context.io, 'Starting open-kritt. Press Ctrl+C to stop the stack.');
   try {
     const result = await context.runner('docker', ['compose', 'up', '--build'], {
@@ -1262,14 +1381,14 @@ Creates .env from .env.example when it does not exist, shows credential status, 
 
 Configure one model provider key or a saved Codex or Claude login. GITHUB_TOKEN is optional and only needed for private GitHub repositories.
 
-The Codex and Claude login flows use temporary engine containers and persist their provider credentials in the same homes monitored by Accounts. OpenRouter keys are saved in .env and mirrored to the managed credential store used by running services.
+The Codex and Claude login flows use temporary engine containers and persist their provider credentials in the same homes monitored by Accounts. Both check first that Docker is running, that the Docker Compose plugin is ${MINIMUM_COMPOSE_VERSION} or newer, and that Compose can read this project, so an unusable Docker is reported instead of an empty login. OpenRouter keys are saved in .env and mirrored to the managed credential store used by running services.
 
 The recommended Codex flow uses device authentication (no localhost callback) and saves auth.json with host-user ownership and private permissions.
 
 Run ./kritt as your normal user, not with sudo. Use Import local login instead of copying auth.json by hand.`,
   start: `Usage: ./kritt start
 
-Checks that .env and at least one model provider credential or Codex login are configured, then runs:
+Checks that .env and at least one model provider credential or Codex login are configured, that the Docker daemon is reachable, that the Docker Compose plugin is ${MINIMUM_COMPOSE_VERSION} or newer, and that Compose can read this project, then runs:
 
   docker compose up --build
 

--- a/scripts/kritt-ui.mjs
+++ b/scripts/kritt-ui.mjs
@@ -6,7 +6,9 @@ import {
   CLAUDE_LOGIN,
   CODEX_LOGIN,
   ENVIRONMENT_ITEMS,
+  checkDockerEnvironment,
   disableManagedProviderCredential,
+  dockerEnvironmentMessage,
   UserCancelledError,
   ensureEnvFile,
   getSetupStatus,
@@ -659,6 +661,20 @@ async function confirmExternalDestination(terminal, context, targetPath) {
   });
 }
 
+// Suspending swaps back to the normal screen buffer, and resuming hides it again, so
+// anything the login prints there is gone by the time a notice appears. Report a Docker
+// problem before that happens.
+async function dockerReady(terminal, context, title) {
+  const preflight = await checkDockerEnvironment({ rootDir: context.rootDir, runner: context.runner });
+  if (preflight.ok) return true;
+  await terminal.notice({
+    title,
+    subtitle: 'Docker is not ready',
+    message: dockerEnvironmentMessage(preflight),
+  });
+  return false;
+}
+
 async function manageCodexLogin(terminal, context) {
   while (true) {
     const status = await getSetupStatus(context);
@@ -732,6 +748,7 @@ async function manageCodexLogin(terminal, context) {
       continue;
     }
     if (!(await confirmExternalDestination(terminal, context, dirname(targetPath)))) continue;
+    if (!(await dockerReady(terminal, context, CODEX_LOGIN.label))) continue;
     await terminal.suspend();
     let result = { ok: false, message: 'Codex login did not complete.' };
     try {
@@ -793,6 +810,7 @@ async function manageClaudeLogin(terminal, context) {
       continue;
     }
 
+    if (!(await dockerReady(terminal, context, CLAUDE_LOGIN.label))) continue;
     await terminal.suspend();
     let saved = false;
     try {

--- a/scripts/kritt-ui.test.mjs
+++ b/scripts/kritt-ui.test.mjs
@@ -85,6 +85,21 @@ class ScriptedTerminal {
   }
 }
 
+// Answers the Docker preflight probes as a healthy host, so these tests exercise the
+// interactive flow rather than the environment check covered in kritt.test.mjs.
+function dockerRunner(handler) {
+  return async (command, args, options) => {
+    if (command === 'docker' && args[0] === 'version') return { code: 0, stdout: '27.3.1\n', stderr: '' };
+    if (command === 'docker' && args[0] === 'compose' && args[1] === 'version') {
+      return { code: 0, stdout: '2.29.7\n', stderr: '' };
+    }
+    if (command === 'docker' && args[0] === 'compose' && args[1] === 'config') {
+      return { code: 0, stdout: '', stderr: '' };
+    }
+    return handler(command, args, options);
+  };
+}
+
 async function createProject(t) {
   const rootDir = await mkdtemp(join(tmpdir(), 'open-kritt-ui-'));
   const templateFile = join(rootDir, '.env.example');
@@ -320,10 +335,10 @@ test('interactive Codex login reports a failed container run without crashing', 
   const result = await runInteractiveCli({
     ...project,
     terminal,
-    runner: async (command, args) => {
+    runner: dockerRunner(async (command, args) => {
       commands.push({ args, command });
       return { code: args[0] === 'compose' ? 1 : 0 };
-    },
+    }),
   });
 
   assert.deepEqual(result, { code: 0 });
@@ -360,4 +375,45 @@ test('TTY detection rejects piped and dumb terminals', () => {
   assert.equal(isInteractiveTerminal({ input, output }, 'xterm-256color'), true);
   assert.equal(isInteractiveTerminal({ input: {}, output }, 'xterm-256color'), false);
   assert.equal(isInteractiveTerminal({ input, output }, 'dumb'), false);
+});
+
+test('interactive Claude login reports a stopped Docker without suspending the terminal', async (t) => {
+  const project = await createProject(t);
+  const commands = [];
+  const terminal = new ScriptedTerminal({
+    choices: ['setup', 'claude-login', 'login', 'back', 'back', 'back'],
+  });
+
+  const result = await runInteractiveCli({
+    ...project,
+    terminal,
+    runner: async (command, args) => {
+      if (args[0] === 'version') {
+        return {
+          code: 1,
+          stdout: '',
+          stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n',
+        };
+      }
+      commands.push(args);
+      return { code: 0, stdout: '2.29.7\n', stderr: '' };
+    },
+  });
+
+  assert.deepEqual(result, { code: 0 });
+  const notice = terminal.notices.find((item) => item.title === 'Claude login');
+  assert.equal(notice.subtitle, 'Docker is not ready');
+  assert.match(notice.message, /The Docker daemon is not reachable/);
+  assert.match(notice.message, /Cannot connect to the Docker daemon/);
+  assert.equal(
+    terminal.calls.some((call) => call === 'suspend'),
+    false
+  );
+  assert.deepEqual(
+    commands.map((args) => args.slice(0, 2)),
+    [
+      ['compose', 'version'],
+      ['compose', 'config'],
+    ]
+  );
 });

--- a/scripts/kritt.test.mjs
+++ b/scripts/kritt.test.mjs
@@ -7,16 +7,19 @@ import { PassThrough } from 'node:stream';
 import test from 'node:test';
 
 import {
+  checkDockerEnvironment,
   createPrompter,
   ensureEnvFile,
   getSetupStatus,
   importCodexAuth,
+  MINIMUM_COMPOSE_VERSION,
   parseEnv,
   resolveHomePath,
   runCli,
   runCommand,
   runSetup,
   runStart,
+  saveDockerClaudeLogin,
   saveDockerCodexLogin,
   setEnvValue,
   syncCodexLoginStatus,
@@ -41,6 +44,33 @@ class BufferStream {
     this.text += value;
     return true;
   }
+}
+
+// The Docker preflight probes the daemon, the Compose plugin version, and whether Compose
+// can read the project. `dockerProbes` answers those three calls so flow assertions below
+// stay focused on the commands each flow runs itself.
+function dockerProbes({ daemon, compose, project } = {}) {
+  // A probe that fails prints its reason on stderr and nothing on stdout.
+  const answer = (override = {}, stdout = '') => ({
+    code: 0,
+    stderr: '',
+    stdout: override.code ? '' : stdout,
+    ...override,
+  });
+  return (command, args) => {
+    if (command !== 'docker') return null;
+    if (args[0] === 'version') return answer(daemon, '27.3.1\n');
+    if (args[0] === 'compose' && args[1] === 'version') return answer(compose, '2.29.7\n');
+    if (args[0] === 'compose' && args[1] === 'config') return answer(project);
+    return null;
+  };
+}
+
+function dockerRunner(handler, probes = dockerProbes()) {
+  return async (command, args, options) => {
+    const probe = probes(command, args);
+    return probe ?? handler(command, args, options);
+  };
 }
 
 function testIo() {
@@ -163,10 +193,10 @@ test('start treats a saved Claude subscription login as model access', async (t)
   const exitCode = await runStart({
     ...project,
     io: testIo(),
-    runner: async (command, args, options) => {
+    runner: dockerRunner(async (command, args, options) => {
       commands.push({ command, args, options });
       return { code: 0 };
-    },
+    }),
   });
 
   assert.equal(status.claudeLoginPresent, true);
@@ -298,13 +328,13 @@ test('guided Claude login uses the shared home monitored by Accounts', async (t)
   const project = await createProject(t);
   const io = testIo();
   const commands = [];
-  const runner = async (command, args, options) => {
+  const runner = dockerRunner(async (command, args, options) => {
     commands.push({ args, command, options });
     const home = join(project.rootDir, '.data', 'claude');
     await mkdir(home, { recursive: true });
     await writeFile(join(home, '.credentials.json'), '{"oauth":{"accessToken":"test"}}', 'utf8');
     return { code: 0 };
-  };
+  });
 
   await runSetup({
     ...project,
@@ -408,13 +438,13 @@ test('guided Docker login copies a host-owned auth file from an isolated contain
   const io = testIo();
   const commands = [];
   const targetPath = join(project.rootDir, '.data', 'codex-accounts', 'cli', '.codex', 'auth.json');
-  const runner = async (command, args, options) => {
+  const runner = dockerRunner(async (command, args, options) => {
     commands.push({ args, command, options });
     if (args[0] === 'cp') {
       await writeFile(args.at(-1), '{"tokens":{"access_token":"test"}}', { encoding: 'utf8', mode: 0o600 });
     }
     return { code: 0 };
-  };
+  });
 
   await runSetup({
     ...project,
@@ -484,10 +514,10 @@ test('guided Docker login cleans up its container when copied auth is missing', 
     io,
     rootDir: project.rootDir,
     targetPath: join(project.rootDir, '.data', 'codex', 'auth.json'),
-    runner: async (command, args, options) => {
+    runner: dockerRunner(async (command, args, options) => {
       commands.push({ args, command, options });
       return { code: args[0] === 'rm' ? 1 : 0 };
-    },
+    }),
   });
 
   assert.equal(result.ok, false);
@@ -513,7 +543,7 @@ for (const [interruptedSignal, exitCode] of [
         rootDir: project.rootDir,
         signalSource,
         targetPath: join(project.rootDir, '.data', 'codex', 'auth.json'),
-        runner: async (command, args, options) => {
+        runner: dockerRunner(async (command, args, options) => {
           commands.push({ args, command, options });
           if (args[0] === 'compose') {
             signalSource.emit(interruptedSignal);
@@ -522,7 +552,7 @@ for (const [interruptedSignal, exitCode] of [
             return { code: 1, signal: interruptedSignal };
           }
           return { code: 0 };
-        },
+        }),
       }),
       (error) => {
         assert.ok(error instanceof UserCancelledError);
@@ -574,10 +604,10 @@ test('start blocks GitHub-only configuration and launches Compose with model acc
   const exitCode = await runStart({
     ...project,
     io: testIo(),
-    runner: async (command, args, options) => {
+    runner: dockerRunner(async (command, args, options) => {
       commands.push({ args, command, options });
       return { code: 0 };
-    },
+    }),
   });
   assert.equal(exitCode, 0);
   assert.deepEqual(commands, [
@@ -648,7 +678,7 @@ test('start repairs the mode of a host-owned Codex home', async (t) => {
   const exitCode = await runStart({
     ...project,
     io: testIo(),
-    runner: async () => ({ code: 0 }),
+    runner: dockerRunner(async () => ({ code: 0 })),
   });
 
   assert.equal(exitCode, 0);
@@ -715,4 +745,152 @@ test('secret prompt keeps using hidden raw-mode input when it is available', asy
   assert.deepEqual(rawModes, [true, false]);
   assert.doesNotMatch(output.text, /visible as you type/);
   assert.doesNotMatch(output.text, new RegExp(apiKey));
+});
+
+test('Docker preflight reports the daemon, the Compose version, and the project as healthy', async (t) => {
+  const project = await createProject(t);
+  const probes = [];
+
+  const preflight = await checkDockerEnvironment({
+    rootDir: project.rootDir,
+    runner: dockerRunner(async (command, args) => {
+      probes.push(args);
+      return { code: 0 };
+    }),
+  });
+
+  assert.deepEqual(preflight, { ok: true, issues: [], serverVersion: '27.3.1', composeVersion: '2.29.7' });
+  assert.deepEqual(probes, []);
+});
+
+test('Docker preflight explains a missing docker executable', async (t) => {
+  const project = await createProject(t);
+
+  const preflight = await checkDockerEnvironment({
+    rootDir: project.rootDir,
+    runner: async () => {
+      throw new Error('Could not run docker: spawn docker ENOENT');
+    },
+  });
+
+  assert.equal(preflight.ok, false);
+  assert.deepEqual(
+    preflight.issues.map((issue) => issue.code),
+    ['docker_missing']
+  );
+  assert.match(preflight.issues[0].message, /spawn docker ENOENT/);
+  assert.match(preflight.issues[0].message, /Install Docker Desktop/);
+});
+
+test('start stops before Compose when the Docker daemon is unreachable', async (t) => {
+  const project = await createProject(t);
+  const io = testIo();
+  await ensureEnvFile(project);
+  await setEnvValue(project.envFile, 'OPENAI_API_KEY', 'sk-example');
+  const commands = [];
+
+  const exitCode = await runStart({
+    ...project,
+    io,
+    runner: dockerRunner(
+      async (command, args) => {
+        commands.push(args);
+        return { code: 0 };
+      },
+      dockerProbes({
+        daemon: {
+          code: 1,
+          stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n',
+        },
+      })
+    ),
+  });
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(commands, []);
+  assert.match(io.error.text, /The Docker daemon is not reachable/);
+  assert.match(io.error.text, /Cannot connect to the Docker daemon/);
+  assert.match(io.error.text, /docker context ls/);
+});
+
+test('start stops before Compose when the Compose plugin predates the flags the CLI uses', async (t) => {
+  const project = await createProject(t);
+  const io = testIo();
+  await ensureEnvFile(project);
+  await setEnvValue(project.envFile, 'OPENAI_API_KEY', 'sk-example');
+  const commands = [];
+
+  const exitCode = await runStart({
+    ...project,
+    io,
+    runner: dockerRunner(
+      async (command, args) => {
+        commands.push(args);
+        return { code: 0 };
+      },
+      dockerProbes({ compose: { code: 0, stdout: 'v2.2.3\n' } })
+    ),
+  });
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(commands, []);
+  assert.match(io.error.text, new RegExp(`Docker Compose 2\\.2\\.3 is too old.*${MINIMUM_COMPOSE_VERSION} or newer`));
+  assert.match(io.error.text, /docker compose run --build/);
+});
+
+test('guided Claude login reports an unreadable Compose project instead of an empty login', async (t) => {
+  const project = await createProject(t);
+  const io = testIo();
+  const home = join(project.rootDir, '.data', 'claude');
+  const commands = [];
+
+  const saved = await saveDockerClaudeLogin({
+    io,
+    home,
+    rootDir: project.rootDir,
+    runner: dockerRunner(
+      async (command, args) => {
+        commands.push(args);
+        return { code: 0 };
+      },
+      dockerProbes({
+        project: {
+          code: 1,
+          stderr:
+            'invalid interpolation format for services.backend.environment.OPEN_KRITT_CODEX_LOGIN_CONFIGURED: "${CODEX_LOGIN_CONFIGURED:+1}".\n',
+        },
+      })
+    ),
+  });
+
+  assert.equal(saved, false);
+  assert.deepEqual(commands, []);
+  assert.match(io.error.text, /Docker Compose could not read this project/);
+  assert.match(io.error.text, /invalid interpolation format/);
+  await assert.rejects(stat(home), { code: 'ENOENT' });
+});
+
+test('guided Codex login returns a Docker environment failure with its reason', async (t) => {
+  const project = await createProject(t);
+  const io = testIo();
+  const commands = [];
+
+  const result = await saveDockerCodexLogin({
+    io,
+    rootDir: project.rootDir,
+    targetPath: join(project.rootDir, '.data', 'codex', 'auth.json'),
+    runner: dockerRunner(
+      async (command, args) => {
+        commands.push(args);
+        return { code: 0 };
+      },
+      dockerProbes({ compose: { code: 1, stderr: "docker: 'compose' is not a docker command.\n" } })
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'docker_unavailable');
+  assert.match(result.message, /The Docker Compose plugin is not available/);
+  assert.match(result.message, /is not a docker command/);
+  assert.deepEqual(commands, []);
 });


### PR DESCRIPTION
## What & why

No linked issue — found while setting up the stack on a host with an outdated Docker Desktop.

The guided Claude login ends with `No login was saved. Review the login output and try again.` whenever the temporary engine container never runs, and the CLI never says why. The cause is usually the host's Docker rather than the login itself:

- the Docker daemon is not running, or `docker context` selects a socket that does not exist;
- the Docker Compose plugin is missing;
- Compose is older than 2.13.0, so `docker compose run --build` — the command both guided logins
  issue — is rejected as an unknown flag;
- Compose cannot parse the project at all. Compose 2.2.3, for example, fails on
  `${CODEX_LOGIN_CONFIGURED:+1}` (`docker-compose.yml:39`) with `invalid interpolation format`,
  which makes every `docker compose` command in this repo fail.

Nothing in `scripts/` checked any of this, so all four surfaced as an unexplained login that saved nothing, or as a raw Compose error from `./kritt start`. The instruction to "review the login output" could not be followed either: the interactive UI suspends to the normal screen buffer for the login and re-enters the alternate buffer on resume, so that output is no longer on screen by the time the notice appears.

This adds a preflight that runs before anything is handed to Compose. `checkDockerEnvironment()`
probes three things and returns structured issues rather than a boolean:

| Check | Command | Catches |
| --- | --- | --- |
| Daemon reachable | `docker version --format {{.Server.Version}}` | Docker not running, wrong context |
| Compose plugin and version | `docker compose version --short` | Missing plugin; older than `2.13.0` |
| Project parses | `docker compose config -q` | The interpolation failure above, and any other `docker-compose.yml` or `.env` error |

A missing `docker` executable is reported separately as `docker_missing`. Each issue quotes Docker's own first line of output, so the message names the real problem instead of paraphrasing it. `2.13.0` is the release that added `--build` to `docker compose run`([docker/compose v2.13.0](https://github.com/docker/compose/releases/tag/v2.13.0)); an
unparseable version string is skipped rather than treated as a failure, so the gate cannot false-positive on an unusual build.

The check gates `runStart`, `saveDockerCodexLogin`, and `saveDockerClaudeLogin` — every path that shells out to Compose. The interactive UI runs it *before* `terminal.suspend()` and reports the issues in a notice, so the diagnosis survives the screen-buffer switch instead of being wiped by `resume()`.

Supporting change: `runCommand` now captures stdout/stderr when a command is piped (capped at 64 KiB), which is what lets the probes quote Docker's own error back to the operator. Callers that inherit stdio are unaffected.

On the host that prompted this, `./kritt start` went from a bare Compose failure to:

```
The Docker daemon is not reachable. Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running? Start Docker Desktop or the docker service, and check "docker context ls" when more than one Docker is installed. Docker Compose 2.2.3 is too old for open-kritt, which needs 2.13.0 or newer: the guided logins run "docker compose run --build". Update Docker, then try again.
```

Both real blockers are reported in one pass, and `./kritt setup` no longer creates an empty `.data/claude` on the way to failing.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `chore` / `test` / `ci`
- [ ] Breaking change (`!` / `BREAKING CHANGE:`)

## Affected components

- [ ] frontend
- [ ] backend
- [ ] engine
- [ ] database (migration)
- [x] docs / CI / tooling (CLI — `scripts/`, docs — `docs-site/`)

## Checklist

By submitting this pull request, you agree to the [Contribution Terms](https://github.com/Kritt-ai/open-kritt/blob/main/CONTRIBUTION_TERMS.md), including assignment of your rights in the contribution. No separate signature, form, or checkbox is required.

- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (no empty `()` scope)
- [x] Lint & format pass — `scripts/` sits outside the repo's prettier/eslint hooks (they target
      `frontend backend`), so the new code was matched to `.prettierrc.json` by hand: 120 columns,
      single quotes, semicolons, ES5 trailing commas. Only unbreakable message string literals
      exceed 120 columns, as they already do elsewhere in `kritt-lib.mjs`.
- [x] Tests added/updated and passing — 64/64 (was 57/57)
- [x] Docs updated if behavior or config changed — `docs-site/getting-started/installation-and-setup.mdx`
- [x] For DB changes — not applicable, no database change
- [x] No secrets committed

## Notes for reviewers

**Checks run**

```bash
node --test scripts/kritt.test.mjs scripts/kritt-ui.test.mjs scripts/kritt-headless.test.mjs
# tests 64 / pass 64 / fail 0   (36 + 14 + 14)
```

Seven tests are new: a healthy-host result, a missing `docker` executable, an unreachable daemon, an outdated Compose plugin, an unreadable Compose project, the Codex `docker_unavailable` result, and a UI test asserting the notice appears and the terminal never suspends.

**Existing command assertions are untouched.** Several tests assert the exact list of commands a flow runs. Rather than rewriting those lists, `dockerProbes`/`dockerRunner` in `kritt.test.mjs` answers the three preflight calls without recording them, so each test still asserts only the commands its own flow issues. The preflight has its own tests instead.

**Behaviour worth a second look**

- The preflight is deliberately run twice on the interactive success path — once by the UI (to report before suspending) and once inside the lib function (so the plain CLI and any future caller are gated too). Three fast local probes ahead of a `--build` Compose run seemed a fair trade for not having an ungated path; happy to thread the result through instead if you prefer.
- `checkDockerEnvironment` aggregates issues rather than returning on the first one, so a host with both a stopped daemon and an ancient Compose sees both in a single run. It does stop early afte  a missing plugin or an outdated Compose, since the later probe would only restate what updating Docker already fixes.
- The daemon probe needs the daemon; the other two are client-side and work while Docker is down.

**Verification beyond the suite.** `checkDockerEnvironment()` was run against a genuinely broken host (Docker Desktop 4.5.0, Docker 20.10.12, Compose 2.2.3, daemon stopped) and `runStart` was exercised end-to-end there against the real `docker` binary in a throwaway project directory, producing the output quoted above.