### PR TITLE
feat(engine): add OpenRouter Ox Alpha efforts

### DIFF
--- a/engine/open_kritt_engine/model_catalog.py
+++ b/engine/open_kritt_engine/model_catalog.py
@@ -24,6 +24,9 @@ LOGGER = logging.getLogger("open_kritt_engine")
 ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models/user"
 OPENROUTER_DEFAULT_MODEL_ID = "z-ai/glm-5.2"
+OPENROUTER_MODEL_THINKING_EFFORTS = {
+    "stealth/ox-alpha": ("low", "high", "max"),
+}
 CATALOG_REFRESH_ERROR = "Unable to refresh the provider model catalog."
 MAX_CATALOG_MODELS = 500
 MAX_CATALOG_PAGES = 10
@@ -421,11 +424,14 @@ def fetch_openrouter_models(api_key: str, timeout_seconds: float) -> tuple[list[
         if not model_id or model_id in seen_ids:
             continue
         seen_ids.add(model_id)
+        thinking_efforts = OPENROUTER_MODEL_THINKING_EFFORTS.get(model_id)
         entries.append(
             {
                 "model": model_id,
                 "displayName": raw.get("name"),
-                "supportedReasoningEfforts": _openrouter_thinking_efforts(raw),
+                "supportedReasoningEfforts": (
+                    list(thinking_efforts) if thinking_efforts else _openrouter_thinking_efforts(raw)
+                ),
                 "isDefault": model_id == OPENROUTER_DEFAULT_MODEL_ID,
             }
         )

--- a/engine/tests/test_model_catalog.py
+++ b/engine/tests/test_model_catalog.py
@@ -325,6 +325,31 @@ def test_fetch_openrouter_models_uses_account_catalog_and_keeps_all_text_models(
     assert timeout == 2
 
 
+def test_fetch_openrouter_models_pins_ox_alpha_thinking_efforts(monkeypatch):
+    entries = [
+        _openrouter_model("z-ai/glm-5.2", name="Z.ai GLM 5.2"),
+        _openrouter_model(
+            "stealth/ox-alpha",
+            name="Ox Alpha",
+            reasoning={"mandatory": True, "supported_efforts": ["low", "high"]},
+        ),
+    ]
+    monkeypatch.setattr(
+        model_catalog,
+        "urlopen",
+        lambda *_args, **_kwargs: io.BytesIO(json.dumps({"data": entries}).encode("utf-8")),
+    )
+
+    models, _default_model = fetch_openrouter_models("openrouter-test-key", 2)
+
+    assert models[1] == {
+        "id": "stealth/ox-alpha",
+        "label": "Ox Alpha",
+        "thinkingEfforts": ["low", "high", "max"],
+        "isDefault": False,
+    }
+
+
 def test_fetch_openrouter_models_uses_provider_default_or_all_gateway_efforts(monkeypatch):
     entries = [
         _openrouter_model(


### PR DESCRIPTION
## What & why

Adds OpenRouter catalog metadata for Ox Alpha (stealth/ox-alpha), pinning its supported thinking efforts to low, high, and max. This keeps the model option aligned with OpenRouter metadata even if an upstream catalog response is incomplete.

## Type of change

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor / chore / test / ci
- [ ] Breaking change

## Affected components

- [ ] frontend
- [ ] backend
- [x] engine
- [ ] database (migration)
- [ ] docs / CI / tooling

## Checklist

- [x] Commits use Conventional Commits
- [ ] Full lint and format suite passes
- [x] Tests added and passing for the changed behavior
- [ ] Docs updated if behavior or config changed
- [ ] Database migration checks (not applicable)
- [x] No secrets committed

## Notes for reviewers

Focused Ruff checks and all model-catalog tests pass. The repository-wide engine suite still contains failures already present on main; none are in the changed model-catalog tests.