### PR TITLE
fix: gracefully skip unsafe symlinks instead of aborting snapshot

### DIFF
--- a/backend/src/lib/localRepos.js
+++ b/backend/src/lib/localRepos.js
@@ -167,12 +167,12 @@ export async function countLocalRepoSnapshotFiles(
         continue;
       }
 
-      fileCount += 1;
       if (entry.isSymbolicLink()) {
-        if (!(await symlinkStaysWithinRoot(entryPath, repoRoot))) snapshotIssues.add('invalid_symlink');
+        if (!(await symlinkStaysWithinRoot(entryPath, repoRoot))) continue;
       } else if (!entry.isFile()) {
         snapshotIssues.add('special_file');
       }
+      fileCount += 1;
       if (fileCount > ceiling) return result(false);
     }
 

--- a/backend/test/localRepos.test.js
+++ b/backend/test/localRepos.test.js
@@ -87,15 +87,15 @@ test('snapshot file counting bounds directory-heavy trees and supports cancellat
   });
 });
 
-test('snapshot file counting flags links the engine cannot safely snapshot', async (t) => {
+test('snapshot file counting omits links the engine safely skips', async (t) => {
   const repo = await temporaryDirectory(t);
   const outside = await temporaryDirectory(t);
   await fs.symlink(outside, path.join(repo, 'outside-link'));
 
   assert.deepEqual(await countLocalRepoSnapshotFiles(repo), {
-    fileCount: 1,
+    fileCount: 0,
     complete: true,
-    snapshotIssues: ['invalid_symlink'],
+    snapshotIssues: [],
   });
 });
 

--- a/engine/open_kritt_engine/repository.py
+++ b/engine/open_kritt_engine/repository.py
@@ -411,6 +411,14 @@ def _copy_local_tree_from_fd(source_fd: int, destination: Path, source_label: Pa
         _copy_local_directory(source_fd, staging, source_label)
         if _directory_changed(source_stat, os.fstat(source_fd)):
             raise RepoError(f"local repository {source_label} changed while it was being snapshotted")
+        skipped_symlinks = _remove_unsafe_snapshot_symlinks(staging)
+        if skipped_symlinks:
+            LOGGER.warning(
+                "Skipped %d absolute or out-of-root symbolic link(s) while snapshotting %s: %s",
+                len(skipped_symlinks),
+                source_label,
+                ", ".join(skipped_symlinks),
+            )
         _validate_local_tree(staging)
         _make_snapshot_readable(staging)
         if destination.exists() or destination.is_symlink():
@@ -474,9 +482,32 @@ def _copy_local_symlink(
         raise RepoError(f"could not read local repository symbolic link {source_label}") from exc
     if not _same_entry(entry_stat, current_stat):
         raise RepoError(f"local repository symbolic link {source_label} changed while it was being snapshotted")
-    if os.path.isabs(target):
-        raise RepoError(f"local repository contains an absolute symbolic link: {source_label}")
     destination.symlink_to(target)
+
+
+def _remove_unsafe_snapshot_symlinks(root: Path) -> list[str]:
+    root_resolved = root.resolve(strict=True)
+    removed: list[str] = []
+    for current_root, dir_names, file_names in os.walk(root, followlinks=False):
+        current = Path(current_root)
+        for name in [*dir_names, *file_names]:
+            path = current / name
+            if not path.is_symlink():
+                continue
+            unsafe = False
+            try:
+                target = os.readlink(path)
+                if os.path.isabs(target):
+                    unsafe = True
+                else:
+                    (path.parent / target).resolve(strict=False).relative_to(root_resolved)
+            except (OSError, RuntimeError, ValueError):
+                unsafe = True
+            if not unsafe:
+                continue
+            removed.append(path.relative_to(root).as_posix())
+            path.unlink()
+    return removed
 
 
 def _copy_local_file(

--- a/engine/tests/test_local_repositories.py
+++ b/engine/tests/test_local_repositories.py
@@ -135,7 +135,7 @@ def test_snapshot_local_repo_rejects_top_level_symlink(tmp_path):
 
 
 @pytest.mark.parametrize("absolute", [False, True], ids=["relative", "absolute"])
-def test_snapshot_local_repo_rejects_outbound_symlink(tmp_path, absolute):
+def test_snapshot_local_repo_skips_outbound_symlink(tmp_path, absolute):
     local_root = tmp_path / "local-repos"
     source = local_root / "repo"
     source.mkdir(parents=True)
@@ -143,21 +143,31 @@ def test_snapshot_local_repo_rejects_outbound_symlink(tmp_path, absolute):
     outside.write_text("outside\n", encoding="utf-8")
     target = str(outside.resolve()) if absolute else "../outside.txt"
     (source / "escape").symlink_to(target)
+    (source / "kept.txt").write_text("kept\n", encoding="utf-8")
 
-    expected = "absolute symbolic link" if absolute else "symbolic link outside its root"
-    with pytest.raises(RepoError, match=expected):
-        snapshot_local_repo("repo", str(tmp_path / "cache"), str(local_root))
+    snapshot_dir, revision = snapshot_local_repo("repo", str(tmp_path / "cache"), str(local_root))
+
+    snapshot = Path(snapshot_dir)
+    assert revision == LOCAL_SNAPSHOT_REVISION
+    assert not (snapshot / "escape").exists()
+    assert not (snapshot / "escape").is_symlink()
+    assert (snapshot / "kept.txt").read_text(encoding="utf-8") == "kept\n"
 
 
-def test_copy_local_snapshot_rejects_outbound_symlink(tmp_path):
+def test_copy_local_snapshot_skips_outbound_symlink(tmp_path):
     source = tmp_path / "source"
     source.mkdir()
     outside = tmp_path / "outside.txt"
     outside.write_text("outside\n", encoding="utf-8")
     (source / "escape").symlink_to("../outside.txt")
 
-    with pytest.raises(RepoError, match="symbolic link outside its root"):
-        copy_local_snapshot(str(source), str(tmp_path / "destination"))
+    destination = tmp_path / "destination"
+    copied_dir, revision = copy_local_snapshot(str(source), str(destination))
+
+    assert copied_dir == str(destination)
+    assert revision == LOCAL_SNAPSHOT_REVISION
+    assert not (destination / "escape").exists()
+    assert not (destination / "escape").is_symlink()
 
 
 def test_snapshot_local_repo_rejects_special_file(tmp_path):

--- a/frontend/src/pages/CreateScan.jsx
+++ b/frontend/src/pages/CreateScan.jsx
@@ -158,7 +158,7 @@ export default function CreateScan() {
           payload.fileCount < 0 ||
           typeof payload.complete !== 'boolean' ||
           !Array.isArray(payload.snapshotIssues) ||
-          payload.snapshotIssues.some((issue) => !['invalid_symlink', 'special_file'].includes(issue))
+          payload.snapshotIssues.some((issue) => issue !== 'special_file')
         ) {
           throw new Error('The local repository file count response was invalid.');
         }
@@ -1584,9 +1584,8 @@ export function LocalRepoFilePreflight({ stats, repoName, configuration, onRetry
 
   const overLimit = preflight.kind === 'over_limit';
   const atLimit = preflight.kind === 'at_limit';
-  const invalidSymlink = visibleStats.snapshotIssues?.includes('invalid_symlink');
   const specialFile = visibleStats.snapshotIssues?.includes('special_file');
-  const snapshotIncompatible = invalidSymlink || specialFile;
+  const snapshotIncompatible = specialFile;
   const progress =
     preflight.maxFiles && (preflight.complete || preflight.isOverLimit)
       ? Math.min(100, Math.max(0, (preflight.fileCount / preflight.maxFiles) * 100))
@@ -1620,14 +1619,8 @@ export function LocalRepoFilePreflight({ stats, repoName, configuration, onRetry
       )}
       {snapshotIncompatible && (
         <div style={{ color: 'var(--fail)', fontWeight: 600, marginTop: progress === null ? 7 : 0 }}>
-          This folder contains{' '}
-          {invalidSymlink && specialFile
-            ? 'absolute or out-of-root symlinks and unsupported special files'
-            : invalidSymlink
-              ? 'one or more absolute or out-of-root symlinks'
-              : 'one or more unsupported special files'}
-          . The engine cannot safely snapshot it, so the scan is expected to fail unless the incompatible entries are
-          removed.
+          This folder contains one or more unsupported special files. The engine cannot safely snapshot it, so the scan
+          is expected to fail unless the incompatible entries are removed.
         </div>
       )}
       <div style={{ color: 'var(--text-2)', marginTop: snapshotIncompatible ? 5 : 0 }}>{preflight.detail}</div>

--- a/frontend/src/pages/CreateScan.test.jsx
+++ b/frontend/src/pages/CreateScan.test.jsx
@@ -95,21 +95,20 @@ describe('local repository file preflight', () => {
     expect(html).not.toContain('data-file-count-progress');
   });
 
-  it('warns when the folder currently contains snapshot-incompatible entries', () => {
+  it('warns about snapshot-blocking special files', () => {
     const html = renderToStaticMarkup(
       createElement(LocalRepoFilePreflight, {
         stats: {
           status: 'ready',
           fileCount: 12,
           complete: true,
-          snapshotIssues: ['invalid_symlink', 'special_file'],
+          snapshotIssues: ['special_file'],
         },
         configuration: '{"max_files":4000}',
         onRetry: () => {},
       })
     );
 
-    expect(html).toContain('absolute or out-of-root symlink');
     expect(html).toContain('unsupported special file');
     expect(html).toContain('scan is expected to fail');
   });


### PR DESCRIPTION
## Summary
- Absolute or out-of-root symbolic links in a local repository no longer cause the snapshot to fail
- Unsafe symlinks are silently removed from the staging copy and logged as a warning, so the scan can proceed on the remaining files
- The frontend no longer warns about `invalid_symlink` issues since the engine handles them transparently

## Test plan
- [x] Backend `localRepos.test.js`: updated to verify invalid symlinks are omitted (not counted or flagged)
- [x] Engine `test_local_repositories.py`: updated to verify snapshot succeeds with outbound symlinks removed
- [x] Frontend `CreateScan.test.jsx`: updated to verify only `special_file` triggers the incompatibility warning